### PR TITLE
Update README.md to point to a better set of Dapr CLI install instructions. 

### DIFF
--- a/1.hello-world/README.md
+++ b/1.hello-world/README.md
@@ -12,7 +12,7 @@ This sample requires you to have the following installed on your machine:
 
 ## Step 1 - Setup Dapr 
 
-Follow [instructions](https://github.com/dapr/cli) to download and install the Dapr CLI and initialize Dapr.
+Follow [instructions](https://github.com/dapr/docs/blob/master/getting-started/environment-setup.md#environment-setup) to download and install the Dapr CLI and initialize Dapr.
 
 ## Step 2 - Understand the Code
 


### PR DESCRIPTION
Current install location takes you (back) to dapr/dapr when there are better instructions available on the dapr/cli page. 