### PR TITLE
Update the python subscriber path

### DIFF
--- a/4.pub-sub/README.md
+++ b/4.pub-sub/README.md
@@ -53,7 +53,7 @@ git clone [-b <dapr_version_tag>] https://github.com/dapr/samples.git
 
 ### Run Python Message Subscriber with Dapr
 
-1. Open a new CLI window and navigate to Python subscriber directory in your CLI: `cd python_subscriber`
+1. Open a new CLI window and navigate to Python subscriber directory in your CLI: `cd python-subscriber`
 2. Install dependencies: `pip install -r requirements.txt` or `python -m pip install -r requirements.txt`
 3. Run Python subscriber app with Dapr: `dapr run --app-id python-subscriber --app-port 5000 python app.py`
     


### PR DESCRIPTION
Just a typo fixed.

# Description

I've updated the python subscriber path according to the real path in the `samples/4.pub-sub`