### PR TITLE
correct "--dapr-http-port" to "--port"

### DIFF
--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -124,7 +124,7 @@ This calls out to our Redis cache to grab the latest value of the "order" key, w
 2. Run Node.js app with Dapr: 
 
     ```sh
-    dapr run --app-id nodeapp --app-port 3000 --dapr-http-port 3500 node app.js
+    dapr run --app-id nodeapp --app-port 3000 --port 3500 node app.js
     ```
 
 The command should output text that looks like the following, along with logs:


### PR DESCRIPTION
```bash
$ dapr run --app-id nodeapp --app-port 3000 --dapr-http-port 3500 node app.js
Error: unknown flag: --dapr-http-port
Usage:
  dapr run [flags]

Flags:
      --app-id string            an id for your application, used for service discovery
      --app-port int             the port your application is listening on (default -1)
      --grpc-port int            the gRPC port for Dapr to listen on (default -1)
      -p, --port int                 the HTTP port for Dapr to listen on (default -1)
```

# Description

In the example, the command `dapr run --app-id nodeapp --app-port 3000 --dapr-http-port 3500 node app.js` is not correct, "--dapr-http-port" should be "--port".

## Issue reference


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
