### PR TITLE
Remove double quotes from metadata

### DIFF
--- a/distributed-calculator/deploy/redis.yaml
+++ b/distributed-calculator/deploy/redis.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   type: state.redis
   metadata:
-  - name: "redisHost"
-    value: "YOUR_REDIS_HOST_HERE"
-  - name: "redisPassword"
-    value: "YOUR_REDIS_PASSWORD_HERE"
+  - name: redisHost
+    value: YOUR_REDIS_HOST_HERE
+  - name: redisPassword
+    value: YOUR_REDIS_PASSWORD_HERE


### PR DESCRIPTION
dapr components does not connect with redis using double-quoted metadata

# Description

Example is using double quotes do not connect on redis.

Please reference the issue this PR will close: #291 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
