### PR TITLE
Fix reference to the hello-world example

### DIFF
--- a/hello-kubernetes/README.md
+++ b/hello-kubernetes/README.md
@@ -1,6 +1,6 @@
 # Hello Kubernetes
 
-This tutorial will get you up and running with Dapr in a Kubernetes cluster. We'll be deploying the same applications from [Hello World](../1.hello-world). To recap, the Python App generates messages and the Node app consumes and persists them. The following architecture diagram illustrates the components that make up this quickstart: 
+This tutorial will get you up and running with Dapr in a Kubernetes cluster. We'll be deploying the same applications from [Hello World](../hello-world). To recap, the Python App generates messages and the Node app consumes and persists them. The following architecture diagram illustrates the components that make up this quickstart: 
 
 ![Architecture Diagram](./img/Architecture_Diagram.png)
 


### PR DESCRIPTION
# Description

The documentation reference on the `hello-kubernetes` example is pointing incorrectly to the previous one (`hello-world`). Maybe this is because of a prior modification on the repository, like a rename of a folder, which caused the reference to be obsolete.

## Issue reference

https://github.com/dapr/quickstarts/issues/303

## Checklist

* [x] You've updated the quickstart's README if necessary