### PR TITLE
Change hello-{world,kubernetes} Python app to also print HTTP error

### DIFF
--- a/hello-kubernetes/python/app.py
+++ b/hello-kubernetes/python/app.py
@@ -3,9 +3,9 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-import time
-import requests
 import os
+import requests
+import time
 
 dapr_port = os.getenv("DAPR_HTTP_PORT", 3500)
 dapr_url = "http://localhost:{}/v1.0/invoke/nodeapp/method/neworder".format(dapr_port)
@@ -17,6 +17,9 @@ while True:
 
     try:
         response = requests.post(dapr_url, json=message, timeout=5)
+        if not response.ok:
+            print("HTTP %d => %s" % (response.status_code,
+                                     response.content.decode("utf-8")), flush=True)
     except Exception as e:
         print(e, flush=True)
 

--- a/hello-world/app.py
+++ b/hello-world/app.py
@@ -3,9 +3,9 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-import time
-import requests
 import os
+import requests
+import time
 
 dapr_port = os.getenv("DAPR_HTTP_PORT", 3500)
 dapr_url = "http://localhost:{}/v1.0/invoke/nodeapp/method/neworder".format(dapr_port)
@@ -17,6 +17,9 @@ while True:
 
     try:
         response = requests.post(dapr_url, json=message, timeout=5)
+        if not response.ok:
+            print("HTTP %d => %s" % (response.status_code,
+                                     response.content.decode("utf-8")), flush=True)
     except Exception as e:
         print(e, flush=True)
 


### PR DESCRIPTION
# Description

During discovery of https://github.com/dapr/dapr/issues/2114 the Python app received an HTTP error (5xx) but did not print a message. The sample code does already have an error handling block, so it looks like the application was hanging.

This changes the Python app to also print 4xx, 5xx response. Such would make it easier for users to see an issue and report.


## Issue reference

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
