### PR TITLE
addresses case inconsistency in pubsubname var

### DIFF
--- a/pub-sub/README.md
+++ b/pub-sub/README.md
@@ -205,12 +205,12 @@ Navigate to the `node-subscriber` directory and open `app.js`, the code for the 
 app.get('/dapr/subscribe', (_req, res) => {
     res.json([
         {
-            pubsubName: "pubsub",
+            pubsubname: "pubsub",
             topic: "A",
             route: "A"
         },
         {
-            pubsubName: "pubsub",
+            pubsubname: "pubsub",
             topic: "B",
             route: "B"
         }
@@ -240,7 +240,7 @@ Navigate to the `python-subscriber` directory and open `app.py`, the code for th
 ```python
 @app.route('/dapr/subscribe', methods=['GET'])
 def subscribe():
-    subscriptions = [{'pubsubName': 'pubsub', 'topic': 'A', 'route': 'A'}, {'pubsubName': 'pubsub', 'topic': 'C', 'route': 'C'}]
+    subscriptions = [{'pubsubname': 'pubsub', 'topic': 'A', 'route': 'A'}, {'pubsubname': 'pubsub', 'topic': 'C', 'route': 'C'}]
     return jsonify(subscriptions)
 ```
 Again, this is how you tell Dapr what topics in which pubsub component to subscribe to. In this case, subscribing to topics "A" and "C" of pubsub component named 'pubsub'. Messages of those topics are handled with the other two routes:

--- a/pub-sub/node-subscriber/app.js
+++ b/pub-sub/node-subscriber/app.js
@@ -15,12 +15,12 @@ const port = 3000;
 app.get('/dapr/subscribe', (_req, res) => {
     res.json([
         {
-            pubsubName: "pubsub",
+            pubsubname: "pubsub",
             topic: "A",
             route: "A"
         },
         {
-            pubsubName: "pubsub",
+            pubsubname: "pubsub",
             topic: "B",
             route: "B"
         }

--- a/pub-sub/python-subscriber/app.py
+++ b/pub-sub/python-subscriber/app.py
@@ -14,7 +14,7 @@ CORS(app)
 
 @app.route('/dapr/subscribe', methods=['GET'])
 def subscribe():
-    subscriptions = [{'pubsubName': 'pubsub', 'topic': 'A', 'route': 'A'}, {'pubsubName': 'pubsub', 'topic': 'C', 'route': 'C'}]
+    subscriptions = [{'pubsubname': 'pubsub', 'topic': 'A', 'route': 'A'}, {'pubsubname': 'pubsub', 'topic': 'C', 'route': 'C'}]
     return jsonify(subscriptions)
 
 @app.route('/A', methods=['POST'])


### PR DESCRIPTION
Part of a larger effort to address pubsubname REST parameter inconsistencies across the Dapr org repos.

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
