### PR TITLE
Remove appconfig from calculator

### DIFF
--- a/distributed-calculator/deploy/dotnet-subtractor.yaml
+++ b/distributed-calculator/deploy/dotnet-subtractor.yaml
@@ -17,7 +17,6 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "subtractapp"
         dapr.io/app-port: "80"
-        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: subtract

--- a/distributed-calculator/deploy/go-adder.yaml
+++ b/distributed-calculator/deploy/go-adder.yaml
@@ -17,7 +17,6 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "addapp"
         dapr.io/app-port: "6000"
-        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: add

--- a/distributed-calculator/deploy/node-divider.yaml
+++ b/distributed-calculator/deploy/node-divider.yaml
@@ -17,7 +17,6 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "divideapp"
         dapr.io/app-port: "4000"
-        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: divide

--- a/distributed-calculator/deploy/python-multiplier.yaml
+++ b/distributed-calculator/deploy/python-multiplier.yaml
@@ -17,7 +17,6 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "multiplyapp"
         dapr.io/app-port: "5000"
-        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: multiply

--- a/distributed-calculator/deploy/react-calculator.yaml
+++ b/distributed-calculator/deploy/react-calculator.yaml
@@ -33,7 +33,6 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "calculator-front-end"
         dapr.io/app-port: "8080"
-        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: calculator-front-end


### PR DESCRIPTION
The YAML files in the distributed calculator sample have a redundant dapr.io/config annotation which makes the sidecars crash, as no Configuration is applied in this quickstart.