### PR TITLE
Add appconfig back with appropriate yaml config

### DIFF
--- a/distributed-calculator/README.md
+++ b/distributed-calculator/README.md
@@ -115,6 +115,7 @@ These instructions start the four calculator operator apps (add, subtract, multi
 
 ## Running the quickstart in a Kubernetes environment
 1. Navigate to the deploy directory in this quickstart directory: `cd deploy`
+   > **Note**: `appconfig.yaml` is not used directly for this quickstart but is present for the [observability quickstart](../observability).
 2. Follow [these instructions](https://docs.dapr.io/getting-started/configure-redis/) to create and configure a Redis store
 3. Deploy all of your resources: `kubectl apply -f .`. 
    > **Note**: Services could also be deployed one-by-one by specifying the .yaml file: `kubectl apply -f go-adder.yaml`.

--- a/distributed-calculator/deploy/appconfig.yaml
+++ b/distributed-calculator/deploy/appconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: appconfig
+spec:
+  tracing:
+    samplingRate: "1"
+
+    

--- a/distributed-calculator/deploy/dotnet-subtractor.yaml
+++ b/distributed-calculator/deploy/dotnet-subtractor.yaml
@@ -17,6 +17,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "subtractapp"
         dapr.io/app-port: "80"
+        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: subtract

--- a/distributed-calculator/deploy/go-adder.yaml
+++ b/distributed-calculator/deploy/go-adder.yaml
@@ -17,6 +17,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "addapp"
         dapr.io/app-port: "6000"
+        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: add

--- a/distributed-calculator/deploy/node-divider.yaml
+++ b/distributed-calculator/deploy/node-divider.yaml
@@ -17,6 +17,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "divideapp"
         dapr.io/app-port: "4000"
+        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: divide

--- a/distributed-calculator/deploy/python-multiplier.yaml
+++ b/distributed-calculator/deploy/python-multiplier.yaml
@@ -17,6 +17,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "multiplyapp"
         dapr.io/app-port: "5000"
+        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: multiply

--- a/distributed-calculator/deploy/react-calculator.yaml
+++ b/distributed-calculator/deploy/react-calculator.yaml
@@ -33,6 +33,7 @@ spec:
         dapr.io/enabled: "true"
         dapr.io/app-id: "calculator-front-end"
         dapr.io/app-port: "8080"
+        dapr.io/config: "appconfig"
     spec:
       containers:
       - name: calculator-front-end


### PR DESCRIPTION
# Description

The distributed calculator quickstart is referenced as an example
in the observability quickstart. This commit adds the appconfig
back into the apps configuration set and introduces the actual
appconfig as well to allow the app to start. This lets users
experience the simplest path for the observability quickstart
while unblocking the calculator.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
