### PR TITLE
Update observability quickstart sample to show OpenTelemetry exporter usage

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -81,10 +81,11 @@ Zipkin as the tracing provider for Dapr.
 
 Deploy Zipkin to your cluster by running:
 ```bash
-# Install Zipkin
 kubectl apply -f ./deploy/zipkin.yaml
+```
 
-# Install the Zipkin exporter component
+Now install a Component that defines Zipkin as the tracing provider for Dapr, and you are done:
+```bash
 kubectl apply -f ./deploy/zipkin-exporter.yaml
 ```
 
@@ -104,7 +105,7 @@ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm
 helm install open-telemetry/opentelemetry-collector -f ./deploy/otel-values.yaml
 ```
 
-Now, install the OpenTelemetry exporter component:
+Now install a Component that defines OpenTelemetry as the tracing provider for Dapr, and you are done:
 ```bash
 kubectl apply -f ./deploy/otel-exporter.yaml
 ```

--- a/observability/README.md
+++ b/observability/README.md
@@ -70,7 +70,7 @@ the second option will be more preferrable.
 
 ### Option 1: Standalone Zipkin exporter
 
-Examine [*./deploy/zipkin.yaml*](./deploy/zipkin.yaml) and see how it includes three sections:
+Examine [*./deploy/zipkin.yaml*](./deploy/zipkin.yaml) and see how it includes two sections:
 
 1. A **Deployment** for Zipkin using the *openzipkin/zipkin* docker image.
 2. A **Service** which will expose Zipkin internally as a ClusterIP in Kubernetes.

--- a/observability/deploy/otel-exporter.yaml
+++ b/observability/deploy/otel-exporter.yaml
@@ -1,0 +1,21 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: appconfig
+  namespace: default
+spec:
+  tracing:
+    samplingRate: "1"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: otel-exporter
+  namespace: default
+spec:
+  type: exporters.native
+  metadata:
+  - name: enabled
+    value: "true"
+  - name: agentEndpoint
+    value: "otel-collector.default.svc.cluster.local:55678"

--- a/observability/deploy/otel-values.yaml
+++ b/observability/deploy/otel-values.yaml
@@ -45,5 +45,3 @@ standaloneCollector:
         traces:
           receivers: [opencensus]
           exporters: [zipkin]
-
-

--- a/observability/deploy/otel-values.yaml
+++ b/observability/deploy/otel-values.yaml
@@ -1,0 +1,49 @@
+nameOverride: "collector"
+
+ports:
+  # Open a port to serve the OpenCensus protocol, which Dapr can use
+  # to talk to OpenTelemetry Collector Agent.
+  opencensus:
+    enabled: true
+    containerPort: 55678
+    servicePort: 55678
+    protocol: TCP
+
+# For the quickstart, we disable the agent collector, since we don't
+# need to scale collector agent using a DaemonSet (i.e. one Pod per
+# Node). Instead we will use the standaloneCollector which doesn't
+# scale as well but has a much smaller footprint.
+#
+# Users with a lot of trace output should reverse the choice here.
+agentCollector:
+  enabled: false
+standaloneCollector:
+  enabled: true
+  # Set a small footprint in term of Pod count and Pod size which
+  # is suitable for the quickstart sample.
+  replicaCount: 1
+  resources:
+    limits :
+      cpu: 1
+      memory: 2Gi
+    requests:
+      cpu: 200m
+      memory: 400Mi
+  configOverride:
+    # Receive traces from OpenCensus format.
+    receivers:
+      opencensus:
+        endpoint: 0.0.0.0:55678
+    # Export traces into Zipkin.
+    exporters:
+      zipkin:
+        endpoint: "http://zipkin.default.svc.cluster.local:9411/api/v2/spans"
+        format: proto
+        insecure: true
+    service:
+      pipelines:
+        traces:
+          receivers: [opencensus]
+          exporters: [zipkin]
+
+

--- a/observability/deploy/zipkin-exporter.yaml
+++ b/observability/deploy/zipkin-exporter.yaml
@@ -1,0 +1,20 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: appconfig
+  namespace: default
+spec:
+  tracing:
+    samplingRate: "1"
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: zipkin
+spec:
+  type: exporters.zipkin
+  metadata:
+  - name: enabled
+    value: "true"
+  - name: exporterAddress
+    value: "http://zipkin.default.svc.cluster.local:9411/api/v2/spans"

--- a/observability/deploy/zipkin.yaml
+++ b/observability/deploy/zipkin.yaml
@@ -37,17 +37,4 @@ spec:
     targetPort: 9411
   type: ClusterIP
 
----
-
-apiVersion: dapr.io/v1alpha1
-kind: Component
-metadata:
-  name: zipkin
-spec:
-  type: exporters.zipkin
-  metadata:
-  - name: enabled
-    value: "true"
-  - name: exporterAddress
-    value: "http://zipkin.default.svc.cluster.local:9411/api/v2/spans"
     


### PR DESCRIPTION
# Description

Update observability quickstart sample to show OpenTelemetry exporter -> Zipkin usage.

Please note that in this PR the OpenTelemetry Collector Helm chart was used. This is so that we don't have to maintain all the independent components ourselves, but instead rely on the Helm chart parameters. I will follow up with another PR to switch the OpenTelemetry how-to in dapr/docs to use the same for simplicity & consistency.

## Issue reference

Please reference the issue this PR will close: #324 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
