### PR TITLE
Add Jaeger instruction to observability quickstart.

### DIFF
--- a/observability/deploy/jaeger.yaml
+++ b/observability/deploy/jaeger.yaml
@@ -1,0 +1,25 @@
+apiVersion: jaegertracing.io/v1
+kind: "Jaeger"
+metadata:
+  name: "jaeger"
+spec:
+  strategy: allInOne
+  ingress:
+    enabled: false
+  allInOne:
+    image: jaegertracing/all-in-one:1.13
+    options:
+      query:
+        base-path: /jaeger
+---
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: zipkin
+spec:
+  type: exporters.zipkin
+  metadata:
+  - name: enabled
+    value: "true"
+  - name: exporterAddress
+    value: "http://jaeger-collector.default.svc.cluster.local:9411/api/v2/spans"


### PR DESCRIPTION
# Description

Add Jaeger instruction to observability quickstart.
## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/docs/issues/693 .

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
