### PR TITLE
Fix quickstart samples to specify `zipkin.endpointAddress`

### DIFF
--- a/distributed-calculator/deploy/appconfig.yaml
+++ b/distributed-calculator/deploy/appconfig.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
-
-    
+    zipkin:
+      endpointAddress: "http://zipkin.default.svc.cluster.local:9411/api/v2/spans"

--- a/observability/README.md
+++ b/observability/README.md
@@ -29,10 +29,13 @@ metadata:
 spec:
   tracing:
     samplingRate: "1"
+    zipkin:
+      endpointAddress: "http://zipkin.default.svc.cluster.local:9411/api/v2/spans"
 ```
 
-`samplingRate` is used to enable or disable the tracing. To disable the sampling rate ,
-set `samplingRate : "0"` in the configuration. The valid range of samplingRate is between 0 and 1 inclusive. The sampling rate determines whether a trace span should be sampled or not based on value. `samplingRate : "1"` will always sample the traces. By default, the sampling rate is 1 in 10,000
+* `samplingRate` is used to enable or disable the tracing. To disable the sampling rate ,
+set `samplingRate : "0"` in the configuration. The valid range of samplingRate is between 0 and 1 inclusive. The sampling rate determines whether a trace span should be sampled or not based on value. `samplingRate : "1"` will always sample the traces. By default, the sampling rate is 1 in 10,000.
+* `zipkin.endpointAddress` is used to specify the trace backend to receive trace using the Zipkin format. Any backend that understands the Zipkin trace format, like Zipkin, Jaeger, New Relic, etc can be used. In this sample, we use the address of the Zipkin server that we will deploy in the next step.
 
 This configuration file enables Dapr tracing. Deploy the configuration by running:
 


### PR DESCRIPTION
# Description

Set `zipkin.endpointAddress` in Configuration used for observability quickstart. These were missed in https://github.com/dapr/quickstarts/pull/337.
## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close:  #336

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
