### PR TITLE
Quickstarts should use latest tag instead of edge (#346)

### DIFF
--- a/bindings/deploy/node.yaml
+++ b/bindings/deploy/node.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: node
-        image: docker.io/dapriosamples/bindings-nodeapp:edge
+        image: docker.io/dapriosamples/bindings-nodeapp:latest
         ports:
         - containerPort: 3000
         imagePullPolicy: Always

--- a/bindings/deploy/python.yaml
+++ b/bindings/deploy/python.yaml
@@ -19,4 +19,4 @@ spec:
     spec:
       containers:
       - name: python
-        image: docker.io/dapriosamples/bindings-pythonapp:edge
+        image: docker.io/dapriosamples/bindings-pythonapp:latest

--- a/distributed-calculator/deploy/dotnet-subtractor.yaml
+++ b/distributed-calculator/deploy/dotnet-subtractor.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: subtract
-        image: dapriosamples/distributed-calculator-csharp:edge
+        image: dapriosamples/distributed-calculator-csharp:latest
         ports:
         - containerPort: 80
         imagePullPolicy: Always

--- a/distributed-calculator/deploy/go-adder.yaml
+++ b/distributed-calculator/deploy/go-adder.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: add
-        image: dapriosamples/distributed-calculator-go:edge
+        image: dapriosamples/distributed-calculator-go:latest
         ports:
         - containerPort: 6000
         imagePullPolicy: Always

--- a/distributed-calculator/deploy/node-divider.yaml
+++ b/distributed-calculator/deploy/node-divider.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: divide
-        image: dapriosamples/distributed-calculator-node:edge
+        image: dapriosamples/distributed-calculator-node:latest
         ports:
         - containerPort: 4000
         imagePullPolicy: Always

--- a/distributed-calculator/deploy/python-multiplier.yaml
+++ b/distributed-calculator/deploy/python-multiplier.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: multiply
-        image: dapriosamples/distributed-calculator-python:edge
+        image: dapriosamples/distributed-calculator-python:latest
         ports:
         - containerPort: 5000
         imagePullPolicy: Always

--- a/distributed-calculator/deploy/react-calculator.yaml
+++ b/distributed-calculator/deploy/react-calculator.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: calculator-front-end
-        image: dapriosamples/distributed-calculator-react-calculator:edge
+        image: dapriosamples/distributed-calculator-react-calculator:latest
         ports:
         - containerPort: 8080
         imagePullPolicy: Always

--- a/hello-kubernetes/deploy/node.yaml
+++ b/hello-kubernetes/deploy/node.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: node
-        image: dapriosamples/hello-k8s-node:edge
+        image: dapriosamples/hello-k8s-node:latest
         ports:
         - containerPort: 3000
         imagePullPolicy: Always

--- a/hello-kubernetes/deploy/python.yaml
+++ b/hello-kubernetes/deploy/python.yaml
@@ -19,4 +19,4 @@ spec:
     spec:
       containers:
       - name: python
-        image: dapriosamples/hello-k8s-python:edge
+        image: dapriosamples/hello-k8s-python:latest

--- a/middleware/deploy/echoapp.yaml
+++ b/middleware/deploy/echoapp.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: echo
-        image: dapriosamples/middleware-echoapp:edge
+        image: dapriosamples/middleware-echoapp:latest
         ports:
         - containerPort: 3000
         imagePullPolicy: Always

--- a/observability/deploy/python-multiplier.yaml
+++ b/observability/deploy/python-multiplier.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: multiply
-        image: dapriosamples/distributed-calculator-slow-python:edge
+        image: dapriosamples/distributed-calculator-slow-python:latest
         ports:
         - containerPort: 5000
         imagePullPolicy: Always

--- a/pub-sub/deploy/node-subscriber.yaml
+++ b/pub-sub/deploy/node-subscriber.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: node-subscriber
-        image: dapriosamples/pubsub-node-subscriber:edge
+        image: dapriosamples/pubsub-node-subscriber:latest
         ports:
         - containerPort: 3000
         imagePullPolicy: Always

--- a/pub-sub/deploy/python-subscriber.yaml
+++ b/pub-sub/deploy/python-subscriber.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: python-subscriber
-        image: dapriosamples/pubsub-python-subscriber:edge
+        image: dapriosamples/pubsub-python-subscriber:latest
         ports:
         - containerPort: 5000
         imagePullPolicy: Always

--- a/pub-sub/deploy/react-form.yaml
+++ b/pub-sub/deploy/react-form.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: react-form
-        image: dapriosamples/pubsub-react-form:edge
+        image: dapriosamples/pubsub-react-form:latest
         ports:
         - containerPort: 8080
         imagePullPolicy: Always

--- a/secretstore/deploy/node.yaml
+++ b/secretstore/deploy/node.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: node
-        image: dapriosamples/secretstorenode:edge
+        image: dapriosamples/secretstorenode:latest
         env:
         - name: SECRET_STORE
           value: "kubernetes"


### PR DESCRIPTION
# Description

Point quickstarts to use 'latest' tag instead of 'edge'

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #346 
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
