### PR TITLE
Update hello-kubernetes and distributed-calculator quickstarts to use a redis.yaml that can work out-of-the-box

### DIFF
--- a/distributed-calculator/deploy/redis.yaml
+++ b/distributed-calculator/deploy/redis.yaml
@@ -5,7 +5,15 @@ metadata:
 spec:
   type: state.redis
   metadata:
+  # These settings will work out of the box if you use `helm install
+  # bitnami/redis`.  If you have your own setup, replace
+  # `redis-master:6379` with your own Redis master address, and the
+  # Redis password with your own Secret.
   - name: redisHost
-    value: YOUR_REDIS_HOST_HERE
+    value: redis-master:6379
   - name: redisPassword
-    value: YOUR_REDIS_PASSWORD_HERE
+    secretKeyRef:
+      name: redis
+      key: redis-password
+auth:
+  secretStore: kubernetes

--- a/distributed-calculator/deploy/redis.yaml
+++ b/distributed-calculator/deploy/redis.yaml
@@ -8,7 +8,8 @@ spec:
   # These settings will work out of the box if you use `helm install
   # bitnami/redis`.  If you have your own setup, replace
   # `redis-master:6379` with your own Redis master address, and the
-  # Redis password with your own Secret.
+  # Redis password with your own Secret's name. For more information,
+  # see https://docs.dapr.io/operations/components/component-secrets .
   - name: redisHost
     value: redis-master:6379
   - name: redisPassword

--- a/hello-kubernetes/README.md
+++ b/hello-kubernetes/README.md
@@ -1,6 +1,6 @@
 # Hello Kubernetes
 
-This tutorial will get you up and running with Dapr in a Kubernetes cluster. We'll be deploying the same applications from [Hello World](../hello-world). To recap, the Python App generates messages and the Node app consumes and persists them. The following architecture diagram illustrates the components that make up this quickstart: 
+This tutorial will get you up and running with Dapr in a Kubernetes cluster. We'll be deploying the same applications from [Hello World](../hello-world). To recap, the Python App generates messages and the Node app consumes and persists them. The following architecture diagram illustrates the components that make up this quickstart:
 
 ![Architecture Diagram](./img/Architecture_Diagram.png)
 
@@ -16,14 +16,14 @@ git clone [-b <dapr_version_tag>] https://github.com/dapr/quickstarts.git
 cd quickstarts
 ```
 > **Note**: See https://github.com/dapr/quickstarts#supported-dapr-runtime-version for supported tags. Use `git clone https://github.com/dapr/quickstarts.git` when using the edge version of dapr runtime.
-  
+
 ## Step 1 - Setup Dapr on your Kubernetes cluster
 
-The first thing you need is an RBAC enabled Kubernetes cluster. This could be running on your machine using Minikube, or it could be a fully-fledged cluser in Azure using [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/). 
+The first thing you need is an RBAC enabled Kubernetes cluster. This could be running on your machine using Minikube, or it could be a fully-fledged cluser in Azure using [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/).
 
 Once you have a cluster, follow the steps below to deploy Dapr to it. For more details, look [here](https://docs.dapr.io/getting-started/install-dapr/#install-dapr-on-a-kubernetes-cluster)
 
-> Please note, that using the CLI does not support non-default namespaces.  
+> Please note, that using the CLI does not support non-default namespaces.
 > If you need a non-default namespace, Helm has to be used (see below).
 
 ```
@@ -40,8 +40,8 @@ $ dapr init --kubernetes
 Dapr can use a number of different state stores (Redis, CosmosDB, DynamoDB, Cassandra, etc) to persist and retrieve state. For this demo, we'll use Redis.
 
 1. Follow [these steps](https://docs.dapr.io/getting-started/configure-redis/) to create a Redis store.
-2. Once your store is created, add the keys to the `redis.yaml` file in the `deploy` directory. 
-    > **Note:** the `redis.yaml` file provided in this quickstart takes plain text secrets. In a production-grade application, follow [secret management](https://docs.dapr.io/developing-applications/building-blocks/secrets/) instructions to securely manage your secrets.
+2. Once your store is created, add the keys to the `redis.yaml` file in the `deploy` directory.
+    > **Note:** the `redis.yaml` file provided in this quickstart will work securely out-of-the-box with a Redis installed with `helm install bitnami/redis`. If you have your own Redis setup, replace the `redisHost` value  with your own Redis master address, and the redisPassword with your own Secret.
 3. Apply the `redis.yaml` file: `kubectl apply -f ./deploy/redis.yaml` and observe that your state store was successfully configured!
 
 ```bash
@@ -60,7 +60,7 @@ This will deploy the Node.js app to Kubernetes. The Dapr control plane will auto
 
 ```dapr.io/app-id: nodeapp``` - this assigns a unique id or name to the Dapr application, so it can be sent messages to and communicated with by other Dapr apps.
 
-You'll also see the container image that you're deploying. If you want to update the code and deploy a new image, see **Next Steps** section. 
+You'll also see the container image that you're deploying. If you want to update the code and deploy a new image, see **Next Steps** section.
 
 This deployment provisions an External IP.
 Wait until the IP is visible: (may take a few minutes)
@@ -82,8 +82,8 @@ Windows
 for /f "delims=" %a in ('kubectl get svc nodeapp --output 'jsonpath={.status.loadBalancer.ingress[0].ip}') do @set NODE_APP=%a
 ```
 
-## Step 4 - Verify Service call using external IP 
-To call the service using the extracted external IP, from a command prompt run: 
+## Step 4 - Verify Service call using external IP
+To call the service using the extracted external IP, from a command prompt run:
 
 ```bash
 $ curl $NODE_APP/ports
@@ -93,7 +93,7 @@ $ curl $NODE_APP/ports
 > Note: This assumes that the external IP is available in the `NODE_APP` environment variable from the previous step.
 Minikube users cannot see the external IP. Instead, you can use `minikube service [service_name]` to access loadbalancer without external IP. Then export it to an environment variable.
 
-Here you can see that two ports are displayed. Both the ports have been injected when Dapr was enabled for this app. Additionally, in this quickstart the HTTP Port is used for further communication with the Dapr sidecar. 
+Here you can see that two ports are displayed. Both the ports have been injected when Dapr was enabled for this app. Additionally, in this quickstart the HTTP Port is used for further communication with the Dapr sidecar.
 
 ## Step 5 - Deploy the Python app with the Dapr sidecar
 Next, take a quick look at the Python app. Navigate to the Python app in the kubernetes quickstart: `cd quickstarts/hello-kubernetes/python` and open `app.py`.

--- a/hello-kubernetes/README.md
+++ b/hello-kubernetes/README.md
@@ -1,6 +1,6 @@
 # Hello Kubernetes
 
-This tutorial will get you up and running with Dapr in a Kubernetes cluster. We'll be deploying the same applications from [Hello World](../hello-world). To recap, the Python App generates messages and the Node app consumes and persists them. The following architecture diagram illustrates the components that make up this quickstart:
+This tutorial will get you up and running with Dapr in a Kubernetes cluster. You will be deploying the same applications from [Hello World](../hello-world). To recap, the Python App generates messages and the Node app consumes and persists them. The following architecture diagram illustrates the components that make up this quickstart:
 
 ![Architecture Diagram](./img/Architecture_Diagram.png)
 
@@ -37,11 +37,11 @@ $ dapr init --kubernetes
 
 ## Step 2 - Create and configure a state store
 
-Dapr can use a number of different state stores (Redis, CosmosDB, DynamoDB, Cassandra, etc) to persist and retrieve state. For this demo, we'll use Redis.
+Dapr can use a number of different state stores (Redis, CosmosDB, DynamoDB, Cassandra, etc) to persist and retrieve state. This demo will use Redis.
 
 1. Follow [these steps](https://docs.dapr.io/getting-started/configure-redis/) to create a Redis store.
 2. Once your store is created, add the keys to the `redis.yaml` file in the `deploy` directory.
-    > **Note:** the `redis.yaml` file provided in this quickstart will work securely out-of-the-box with a Redis installed with `helm install bitnami/redis`. If you have your own Redis setup, replace the `redisHost` value  with your own Redis master address, and the redisPassword with your own Secret.
+    > **Note:** the `redis.yaml` file provided in this quickstart will work securely out-of-the-box with a Redis installed with `helm install bitnami/redis`. If you have your own Redis setup, replace the `redisHost` value  with your own Redis master address, and the redisPassword with your own Secret. You can learn more [here](https://docs.dapr.io/operations/components/component-secrets/).
 3. Apply the `redis.yaml` file: `kubectl apply -f ./deploy/redis.yaml` and observe that your state store was successfully configured!
 
 ```bash

--- a/hello-kubernetes/deploy/redis.yaml
+++ b/hello-kubernetes/deploy/redis.yaml
@@ -5,7 +5,15 @@ metadata:
 spec:
   type: state.redis
   metadata:
+  # These settings will work out of the box if you use `helm install
+  # bitnami/redis`.  If you have your own setup, replace
+  # `redis-master:6379` with your own Redis master address, and the
+  # Redis password with your own Secret.
   - name: redisHost
-    value: YOUR_REDIS_HOST_HERE:6379
+    value: redis-master:6379
   - name: redisPassword
-    value: YOUR_REDIS_KEY_HERE
+    secretKeyRef:
+      name: redis
+      key: redis-password
+auth:
+  secretStore: kubernetes

--- a/hello-kubernetes/deploy/redis.yaml
+++ b/hello-kubernetes/deploy/redis.yaml
@@ -8,7 +8,8 @@ spec:
   # These settings will work out of the box if you use `helm install
   # bitnami/redis`.  If you have your own setup, replace
   # `redis-master:6379` with your own Redis master address, and the
-  # Redis password with your own Secret.
+  # Redis password with your own Secret's name. For more information,
+  # see https://docs.dapr.io/operations/components/component-secrets .
   - name: redisHost
     value: redis-master:6379
   - name: redisPassword


### PR DESCRIPTION
# Description

* Update hello-kubernetes and distributed-calculator quickstarts to use a redis.yaml that can work out-of-the-box.


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
