### PR TITLE
Increase timeout for helm install of kafka in bindings sample (#369)

### DIFF
--- a/bindings/README.md
+++ b/bindings/README.md
@@ -244,6 +244,7 @@ docker-compose -f ./docker-compose-single-kafka.yml down
 <!-- STEP
 name: Install Kafka
 sleep: 15
+timeout_seconds: 120
 -->
 
 ```bash


### PR DESCRIPTION
# Description

Helm kafka install was timing out at the default 60s. Upping the timeout to 120s

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #369

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
