### PR TITLE
Update runtime to 1.0.0-rc.4

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,9 +21,9 @@ jobs:
     name: Validate ${{ matrix.quickstart }}/README.md on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v1.0.0-rc.4/install
-      DAPR_CLI_VERSION: 1.0.0-rc.4
-      DAPR_RUNTIME_VERSION: 1.0.0-rc.3
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v1.0.0-rc.5/install
+      DAPR_CLI_VERSION: 1.0.0-rc.5
+      DAPR_RUNTIME_VERSION: 1.0.0-rc.4
       GOVER: 1.15.3
       KUBERNETES_VERSION: v1.18.8
       KIND_VERSION: v0.9.0

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -357,9 +357,9 @@ Look at the Node app logs by running:
 name: Read Node Logs
 expected_stdout_lines:
   - Hello from Kafka!
-  - "{ orderId: 10 }"
+  - "{ orderId: 16 }"
   - Hello from Kafka!
-  - "{ orderId: 11 }"
+  - "{ orderId: 17 }"
 -->
 
 ```bash

--- a/distributed-calculator/csharp/Dockerfile
+++ b/distributed-calculator/csharp/Dockerfile
@@ -1,18 +1,7 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-buster-slim-amd64 AS build-env
-WORKDIR /app
-ARG DOTNET_PLATFORM="x64"
-
-
-# Copy csproj and restore as distinct layers
-COPY *.csproj ./
-RUN dotnet restore -r linux-${DOTNET_PLATFORM}
-
-# Copy everything else and build
-COPY . ./
-RUN dotnet publish -c Release -o out
+# Note: we cannot do a staged dotnet docker build here for arm/arm64. 
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:3.1
 WORKDIR /app
-COPY --from=build-env /app/out .
+COPY  /out .
 ENTRYPOINT ["dotnet", "Subtract.dll"]

--- a/distributed-calculator/go/Dockerfile
+++ b/distributed-calculator/go/Dockerfile
@@ -5,7 +5,7 @@ COPY app.go .
 RUN go get -d -v
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 #second stage
-FROM scratch
+FROM debian:buster-slim
 WORKDIR /root/
 COPY --from=builder /dir/app .
 CMD ["./app"]

--- a/distributed-calculator/makefile
+++ b/distributed-calculator/makefile
@@ -1,5 +1,16 @@
 DOCKER_IMAGE_PREFIX ?= distributed-calculator-
 APPS                ?= node python go csharp react-calculator
-
+	
 include ../docker.mk
 include ../validate.mk
+
+TARGET_DOTNET_PLATFORM = $(TARGET_ARCH)
+ifeq ($(TARGET_DOTNET_PLATFORM),amd64)
+  TARGET_DOTNET_PLATFORM = x64
+endif
+
+build-csharp-local:
+	cd csharp && dotnet restore -r linux-$(TARGET_DOTNET_PLATFORM)
+	cd csharp && dotnet publish -c Release -o out
+
+build-csharp: build-csharp-local

--- a/docker.mk
+++ b/docker.mk
@@ -13,11 +13,6 @@ ifeq ($(REL_VERSION),edge)
 	REL_VERSION := latest
 endif
 
-TARGET_DOTNET_PLATFORM = $(TARGET_ARCH)
-ifeq ($(TARGET_DOTNET_PLATFORM),amd64)
-  TARGET_DOTNET_PLATFORM = x64
-endif
-
 # Docker image build and push setting
 DOCKER:=docker
 DOCKERFILE:=Dockerfile
@@ -32,7 +27,7 @@ build: $(BUILD_APPS)
 define genDockerImageBuild
 .PHONY: build-$(1)
 build-$(1):
-	$(DOCKER) build --build-arg DOTNET_PLATFORM=$(TARGET_DOTNET_PLATFORM) -f $(1)/$(DOCKERFILE) $(1)/. -t $(SAMPLE_REGISTRY)/$(DOCKER_IMAGE_PREFIX)$(1):$(REL_VERSION)-$(TARGET_OS)-$(TARGET_ARCH) --platform $(TARGET_OS)/$(TARGET_ARCH)
+	$(DOCKER) build -f $(1)/$(DOCKERFILE) $(1)/. -t $(SAMPLE_REGISTRY)/$(DOCKER_IMAGE_PREFIX)$(1):$(REL_VERSION)-$(TARGET_OS)-$(TARGET_ARCH) --platform $(TARGET_OS)/$(TARGET_ARCH)
 endef
 
 # Generate docker image build targets


### PR DESCRIPTION
# Description

Bump runtime version for validation.

Also, scratch image is not supported in arm64. Use a multiarch image instead.

Turns out, the dotnet build container will not run on arm64, but you can cross compile from the amd64 host and copy the binaries. 

close: #345

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
