### PR TITLE
Add link validation to quickstarts

### DIFF
--- a/distributed-calculator/README.md
+++ b/distributed-calculator/README.md
@@ -264,7 +264,7 @@ expected_stdout_lines:
   - "18"
   - "12"
   - "1768.0"
-  - '    "total": "54"'
+  - '"54"'
 name: "Curl test"
 -->
 
@@ -275,7 +275,7 @@ name: "Curl test"
    curl -w "\n" -s 'http://localhost:8080/calculate/divide' -H 'Content-Type: application/json' --data '{"operandOne":"144","operandTwo":"12"}'
    curl -w "\n" -s 'http://localhost:8080/calculate/multiply' -H 'Content-Type: application/json' --data '{"operandOne":"52","operandTwo":"34"}'
    curl -w "\n" -s 'http://localhost:8080/persist' -H 'Content-Type: application/json' --data '[{"key":"calculatorState","value":{"total":"54","next":null,"operation":null}}]'
-   curl -s 'http://localhost:8080/state' | python -m json.tool
+   curl -s 'http://localhost:8080/state' | jq '.total'
    ```
 
 <!-- END_STEP -->
@@ -287,11 +287,7 @@ name: "Curl test"
    12
    1768.0
    
-   {
-       "next": null,
-       "operation": null,
-       "total": "54"
-   }   
+   "54"
    ```
 
 <!-- STEP
@@ -464,7 +460,7 @@ expected_stdout_lines:
   - "18"
   - "12"
   - "1768.0"
-  - '    "total": "54"'
+  - '"54"'
 name: "Curl test"
 -->
 
@@ -474,7 +470,7 @@ curl -w "\n" -s 'http://localhost:8000/calculate/subtract' -H 'Content-Type: app
 curl -w "\n" -s 'http://localhost:8000/calculate/divide' -H 'Content-Type: application/json' --data '{"operandOne":"144","operandTwo":"12"}'
 curl -w "\n" -s 'http://localhost:8000/calculate/multiply' -H 'Content-Type: application/json' --data '{"operandOne":"52","operandTwo":"34"}'
 curl -w "\n" -s 'http://localhost:8000/persist' -H 'Content-Type: application/json' --data '[{"key":"calculatorState","value":{"total":"54","next":null,"operation":null}}]'
-curl -s 'http://localhost:8000/state' | python -m json.tool
+curl -s 'http://localhost:8000/state' | jq '.total'
 ```
 
 <!-- END_STEP -->
@@ -487,11 +483,7 @@ You should get the following output:
    12
    1768.0
    
-   {
-       "next": null,
-       "operation": null,
-       "total": "54"
-   }   
+   "54"
    ```
 
 ## Cleanup

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,6 +1,6 @@
 # Observability with Dapr
 
-This quickstart explores the [observability](https://docs.dapr.io/concepts/observability-concept/) capabilities of Dapr. Observability includes metric collection, tracing, logging and health checks. In this quickstart you'll be enabling [distributed tracing](https://docs.dapr.io/developing-applications/building-blocks/observability/tracing/) on an application without changing any application code or creating a dependency on any specific tracing system. Since Dapr uses [OpenCensus](https://opencensus.io/), a variety of observability tools can be used to view and capture the traces.
+This quickstart explores the [observability](https://docs.dapr.io/concepts/observability-concept/) capabilities of Dapr. Observability includes metric collection, tracing, logging and health checks. In this quickstart you'll be enabling [distributed tracing](https://docs.dapr.io/developing-applications/building-blocks/observability/tracing-overview/) on an application without changing any application code or creating a dependency on any specific tracing system. Since Dapr uses [OpenCensus](https://opencensus.io/), a variety of observability tools can be used to view and capture the traces.
 
 In this quickstart you will:
 
@@ -364,7 +364,11 @@ manual_pause_message: "Zipkin tracing running on http://localhost:19411. Please 
 
 <!-- END_STEP -->
 
+<!-- IGNORE_LINKS -->
+
 And browsing to [http://localhost:19411](http://localhost:19411). Click the search button to view tracing coming from the application:
+
+<!-- END_IGNORE -->
 
 ![Zipkin](./img/zipkin-1.png)
 
@@ -458,7 +462,7 @@ kubectl delete -f deploy/zipkin.yaml
 ## Additional Resources
 
 - Learn more about [observability](https://docs.dapr.io/concepts/observability-concept/).
-- Learn more on how Dapr does [distributed tracing](https://docs.dapr.io/developing-applications/building-blocks/observability/tracing/).
+- Learn more on how Dapr does [distributed tracing](https://docs.dapr.io/developing-applications/building-blocks/observability/tracing-overview/).
 
 ## Next steps
 

--- a/validate.mk
+++ b/validate.mk
@@ -1,3 +1,3 @@
 
 validate:
-	mm.py README.md
+	mm.py -l README.md


### PR DESCRIPTION
# Description

Mechanical markdown now supports link validation. It will automatically parse links for external domains to ensure that they are available.

```bash

External link validation:
	https://docs.docker.com/ Status: 200
	https://nodejs.org/en/ Status: 200
	https://www.python.org/downloads/ Status: 200
	https://www.getpostman.com/ Status: 200
	https://docs.dapr.io/getting-started/install-dapr/ Status: 200
	https://marketplace.visualstudio.com/items?itemName=humao.rest-client Status: 200
	https://marketplace.visualstudio.com/items?itemName=humao.rest-client Status: 200
	https://github.com/dapr/quickstarts/issues/240 Status: 200
	https://docs.dapr.io/concepts/overview/ Status: 200
	https://docs.dapr.io/concepts/ Status: 200
```

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #394

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
