### PR TITLE
fix typo in "cluser"

### DIFF
--- a/hello-kubernetes/README.md
+++ b/hello-kubernetes/README.md
@@ -19,7 +19,7 @@ cd quickstarts
 
 ## Step 1 - Setup Dapr on your Kubernetes cluster
 
-The first thing you need is an RBAC enabled Kubernetes cluster. This could be running on your machine using Minikube, or it could be a fully-fledged cluser in Azure using [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/).
+The first thing you need is an RBAC enabled Kubernetes cluster. This could be running on your machine using Minikube, or it could be a fully-fledged cluster in Azure using [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/).
 
 Once you have a cluster, follow the steps below to deploy Dapr to it. For more details, look [here](https://docs.dapr.io/getting-started/install-dapr/#install-dapr-on-a-kubernetes-cluster)
 


### PR DESCRIPTION
"cluser" → "cluster"
Really, it's just one character! 😄 