### PR TITLE
Update to go 1.16.3 for validation tests

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -24,7 +24,7 @@ jobs:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v1.2.0-rc.2/install
       DAPR_CLI_VERSION: 1.2.0-rc.2
       DAPR_RUNTIME_VERSION: 1.2.0-rc.4
-      GOVER: 1.15.3
+      GOVER: 1.16.3
       KUBERNETES_VERSION: v1.18.8
       KIND_VERSION: v0.9.0
       KIND_IMAGE_SHA: sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb

--- a/distributed-calculator/go/go.mod
+++ b/distributed-calculator/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/dapr/quickstarts/distributed-calculator/go
+
+go 1.16
+
+require github.com/gorilla/mux v1.8.0

--- a/distributed-calculator/go/go.sum
+++ b/distributed-calculator/go/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=


### PR DESCRIPTION
# Description

Latest go version 1.16.3 no longer supports building without a go.mod file.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
