### PR TITLE
Fix link to go-sdk examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Find SDK-specific samples in the links below:
   - **[Examples](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples)** - Examples for developing Java applications using Dapr
   - **[Example for Java Actors](https://github.com/dapr/java-sdk/tree/master/examples/src/main/java/io/dapr/examples/actors)** - Example for developing an actor application using the Java SDK.
 - **[Go SDK](https://github.com/dapr/go-sdk)** 
-  - **[Examples](https://github.com/dapr/go-sdk/tree/master/example#dapr-go-client-example)** using the client library to connect to Dapr API, and how to create a Dapr application in either HTTP or gRPC.
+  - **[Examples](https://github.com/dapr/go-sdk/tree/master/examples#dapr-go-client-example)** using the client library to connect to Dapr API, and how to create a Dapr application in either HTTP or gRPC.
 - **[Javascript SDK](https://github.com/dapr/js-sdk)**
   - **[Examples](https://github.com/dapr/js-sdk/tree/master/examples)** - Examples for developing Javascript applications using Dapr
 - **[Python SDK](https://github.com/dapr/python-sdk)**


### PR DESCRIPTION
# Description

https://github.com/dapr/go-sdk/pull/171 changed the location of examples in the dapr/go-sdk project and breaks the link validation for README.md in dapr/quickstarts that pointed to it.

This PR repairs that link and unblocks validation workflows in the quickstarts repo.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
