### PR TITLE
Fix issue template metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a bug in Dapr
+about: Report a bug in Dapr quickstarts
 title: ''
 labels: kind/bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,6 +1,6 @@
 ---
-name: Feature Request
-about: Start a discussion for Dapr
+name: Discussion
+about: Start a discussion for Dapr quickstarts
 title: ''
 labels: kind/discussion
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Create a Feature Request for Dapr
+about: Create a Feature Request for Dapr quickstarts
 title: ''
 labels: kind/enhancement
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,6 +1,6 @@
 ---
 name: Proposal
-about: Create a proposal for Dapr
+about: Create a proposal for Dapr quickstarts
 title: ''
 labels: kind/proposal
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about Dapr
+about: Ask a question about Dapr quickstarts
 title: ''
 labels: kind/question
 assignees: ''


### PR DESCRIPTION
# Description

A collision in the name field was causing some of the templates to be not displayed. Also change the about field to make it clear that this queue is for issues related to quickstarts specifically.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
