### PR TITLE
Do not run any part of the build at container start for pubsub-react

### DIFF
--- a/pub-sub/react-form/Dockerfile
+++ b/pub-sub/react-form/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:8-alpine
 WORKDIR /usr/src/app
 COPY . .
-RUN npm install
-RUN cd client && npm install
+RUN npm run build
 EXPOSE 8080
-CMD [ "npm", "run", "buildandstart" ]
+CMD [ "npm", "run", "start" ]

--- a/pub-sub/react-form/package.json
+++ b/pub-sub/react-form/package.json
@@ -10,7 +10,7 @@
     "dev": "concurrently --kill-others-on-fail \"yarn server\" \"yarn client\"",
     "start": "node server.js",
     "buildclient": "cd client && npm install && npm run build",
-    "buildandstart": "npm run buildclient && npm install && npm run start"
+    "build": "npm run buildclient && npm install"
   },
   "author": "Ryan Volum",
   "license": "ISC",


### PR DESCRIPTION
# Description

It wasn't enough just to pre install everything, we actually have to run the full build for the client side to speed up pubsub-react container.

Manually tested on my local machine, this brings container startup. to <2s from 40+

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
