### PR TITLE
Update golang extension in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "Dapr Quickstarts Codespace",
   "dockerFile": "Dockerfile",
   "extensions": [
-    "ms-vscode.go",
+    "golang.go",
     "ms-azuretools.vscode-dapr",
     "ms-azuretools.vscode-docker",
     "ms-kubernetes-tools.vscode-kubernetes-tools"


### PR DESCRIPTION
# Description

Replace the deprecated `ms-vscode.go` extension with the currently supported `golang.go` extension in the Dapr devcontainer definition.

## Issue reference

Applies the fix for https://github.com/dapr/components-contrib/issues/1022 into the dapr/quickstarts repo as well.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
