### PR TITLE
Update .dockerignore

### DIFF
--- a/distributed-calculator/csharp/.dockerignore
+++ b/distributed-calculator/csharp/.dockerignore
@@ -1,2 +1,2 @@
-bin\
-obj\
+bin/
+obj/


### PR DESCRIPTION
The .dockerignore file must use forward slashes.

# Description

Fixes dotnet container build issue.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
