### PR TITLE
Add a bit more memory for minikube to use

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -36,6 +36,9 @@ jobs:
         with:
           docker_buildx: false
           docker_version: 20.10
+      - name: docker login
+        run: |
+          docker login -u ${{ secrets.DOCKER_REGISTRY_ID }} -p ${{ secrets.DOCKER_REGISTRY_PASS }}
       - name: Configure KinD
         if: matrix.os == 'ubuntu-latest'
         # Generate a KinD configuration file that uses:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           brew install kubernetes-cli || brew link --overwrite kubernetes-cli
           brew install minikube
-          minikube start --driver=virtualbox --memory 4096 --host-only-cidr "192.168.59.1/24"
+          minikube start --driver=virtualbox --memory 6144 --host-only-cidr "192.168.59.1/24"
       - name: Get KinD info
         if: matrix.os == 'ubuntu-latest'
         run: |


### PR DESCRIPTION
# Description

The distributed calculator deploy is occasionally getting hung waiting for containers to get scheduled. Key suspect is memory pressure.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
