### PR TITLE
hello-world - add folder paths to launch for split projects

### DIFF
--- a/tutorials/hello-world/.gitignore
+++ b/tutorials/hello-world/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+!.vscode

--- a/tutorials/hello-world/.vscode/launch.json
+++ b/tutorials/hello-world/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Nodeapp with Dapr",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/node/app.js",
+            "preLaunchTask": "daprd-debug-node",
+            "postDebugTask": "daprd-down-node"
+        },
+        {
+            "type": "python",
+            "request": "launch",
+            "name": "Pythonapp with Dapr",
+            "program": "${workspaceFolder}/python/app.py",   
+            "console": "integratedTerminal",
+            "preLaunchTask": "daprd-debug-python",
+            "postDebugTask": "daprd-down-python"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Node/Python Dapr",
+            "configurations": ["Nodeapp with Dapr","Pythonapp with Dapr"]
+                }
+    ]
+}

--- a/tutorials/hello-world/.vscode/tasks.json
+++ b/tutorials/hello-world/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"appId": "nodeapp",
+			"appPort": 3000,
+			"httpPort": 3500,
+			"metricsPort": 9090,
+			"label": "daprd-debug-node",
+			"type": "daprd"
+		},
+		{
+			"appId": "nodeapp",
+			"label": "daprd-down-node",
+			"type": "daprd-down"
+		},
+		{
+			"appId": "pythonapp",
+			"httpPort": 53109,
+			"grpcPort": 53317,
+			"metricsPort": 9091,
+			"label": "daprd-debug-python",
+			"type": "daprd"
+		},
+		{
+			"appId": "pythonapp",
+			"label": "daprd-down-python",
+			"type": "daprd-down"
+		}
+	]
+}


### PR DESCRIPTION
# Description

In the hello-world quickstart, I added folder paths to launch.json for split projects.  The combination of adding in the split project folders for node and python as well as the addition of the VS Code debugging configurations are out of synch and corrected by adding the additional folder paths in launch.json for the hello-world quickstart.

## Issue reference

closes #492 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
