### PR TITLE
Added latest dashboard version environment variable to automatically pull for E2E tests

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -93,6 +93,12 @@ jobs:
           echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
           echo "Found $RUNTIME_VERSION"
         shell: bash
+      - name: Determine latest Dapr Dashboard version including Pre-releases
+        run: |
+          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export DASHBOARD_VERSION=$(helm search repo dapr/dashboard --devel --versions | awk '/dapr\/dashboard/ {print $3; exit}' )
+          echo "DAPR_DASHBOARD_VERSION=$DASHBOARD_VERSION" >> $GITHUB_ENV
+          echo "Found $DASHBOARD_VERSION"
+        shell: bash  
       - name: Determine latest Dapr Cli version including Pre-releases
         run: |
           export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')


### PR DESCRIPTION
# Description

Added a script to read latest Dapr dashboard version and assign to an environment variable. And read it for pulling the automatic dashboard version for E2E tests.



We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: [#832](https://github.com/dapr/cli/issues/832)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
