### PR TITLE
Fix upstream issue in Create-React-App

### DIFF
--- a/distributed-calculator/react-calculator/Dockerfile
+++ b/distributed-calculator/react-calculator/Dockerfile
@@ -2,6 +2,11 @@ FROM node:17-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install
+
+# Add mini-css-extract-plugin custom install since it's not correctly installed in create-react-app
+# https://github.com/facebook/create-react-app/issues/11930
+RUN npm i -D --save-exact mini-css-extract-plugin@2.4.5
+
 RUN npm run buildclient
 EXPOSE 8080
 EXPOSE 3000

--- a/distributed-calculator/react-calculator/Dockerfile
+++ b/distributed-calculator/react-calculator/Dockerfile
@@ -2,11 +2,6 @@ FROM node:17-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install
-
-# Add mini-css-extract-plugin custom install since it's not correctly installed in create-react-app
-# https://github.com/facebook/create-react-app/issues/11930
-RUN npm i -D --save-exact mini-css-extract-plugin@2.4.5
-
 RUN npm run buildclient
 EXPOSE 8080
 EXPOSE 3000

--- a/distributed-calculator/react-calculator/Dockerfile
+++ b/distributed-calculator/react-calculator/Dockerfile
@@ -2,7 +2,11 @@ FROM node:17-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install
-RUN npm run buildclient
+
+# Build the client
+RUN cd client; npm i
+
 EXPOSE 8080
 EXPOSE 3000
+
 CMD [ "npm", "run", "start" ]

--- a/distributed-calculator/react-calculator/client/package.json
+++ b/distributed-calculator/react-calculator/client/package.json
@@ -1,32 +1,36 @@
 {
-  "name": "client",
-  "version": "0.1.0",
-  "private": true,
-  "dependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "react-scripts": "^5.0.0"
-  },
-  "proxy": "http://localhost:8080/",
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+    "name": "client",
+    "version": "0.1.0",
+    "private": true,
+    "proxy": "http://localhost:8080/",
+    "scripts": {
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject"
+    },
+    "dependencies": {
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0",
+        "react-scripts": "^5.0.0",
+        "mini-css-extract-plugin": "2.4.5"
+    },
+    "resolutions": {
+        "mini-css-extract-plugin": "2.4.5"
+    },
+    "eslintConfig": {
+        "extends": "react-app"
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
+    }
 }

--- a/distributed-calculator/react-calculator/package.json
+++ b/distributed-calculator/react-calculator/package.json
@@ -11,13 +11,9 @@
     "dependencies": {
         "body-parser": "^1.18.3",
         "express": "^4.16.4",
-        "request": "^2.88.0",
-        "mini-css-extract-plugin": "2.4.5"
+        "request": "^2.88.0"
     },
     "devDependencies": {
         "concurrently": "^4.0.1"
-    },
-    "resolutions": {
-        "mini-css-extract-plugin": "2.4.5"
     }
 }

--- a/distributed-calculator/react-calculator/package.json
+++ b/distributed-calculator/react-calculator/package.json
@@ -1,19 +1,23 @@
 {
-  "name": "react-docker-app",
-  "version": "1.0.0",
-  "scripts": {
-    "client": "cd client && yarn start",
-    "server": "nodemon server.js",
-    "dev": "concurrently --kill-others-on-fail \"yarn server\" \"yarn client\"",
-    "start": "node server.js",
-    "buildclient": "cd client && npm install && npm install --only=dev --no-shrinkwrap && npm run build"
-  },
-  "dependencies": {
-    "body-parser": "^1.18.3",
-    "express": "^4.16.4",
-    "request": "^2.88.0"
-  },
-  "devDependencies": {
-    "concurrently": "^4.0.1"
-  }
+    "name": "react-docker-app",
+    "version": "1.0.0",
+    "scripts": {
+        "client": "cd client && yarn start",
+        "server": "nodemon server.js",
+        "dev": "concurrently --kill-others-on-fail \"yarn server\" \"yarn client\"",
+        "start": "node server.js",
+        "buildclient": "cd client && npm install && npm install --only=dev --no-shrinkwrap && npm run build"
+    },
+    "dependencies": {
+        "body-parser": "^1.18.3",
+        "express": "^4.16.4",
+        "request": "^2.88.0",
+        "mini-css-extract-plugin": "2.4.5"
+    },
+    "devDependencies": {
+        "concurrently": "^4.0.1"
+    },
+    "resolutions": {
+        "mini-css-extract-plugin": "2.4.5"
+    }
 }


### PR DESCRIPTION
# Description

There is a bug upstream in Create-React-App that doesn't initialize the MiniCssExtractPlugin correctly anymore as it is now requiring Types

## Issue reference

## Checklist
