### PR TITLE
Update DevContainer base image to fix CodeSpaces and DevContainer issues

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-FROM mcr.microsoft.com/vscode/devcontainers/universal:1.6.9-focal
+FROM mcr.microsoft.com/vscode/devcontainers/universal:1-focal
 
 # Copy custom first notice message.
 COPY first-run-notice.txt /tmp/staging/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a collection of tutorials with code samples that are ai
 If you are new to Dapr and haven't done so already, it is recommended you go through the Dapr [Getting Started](https://docs.dapr.io/getting-started/install-dapr/) instructions.
 
 If you would like to jump in right away by using [GitHub Codespaces](https://github.com/features/codespaces), you can click on "Code" in this repo and "Open with Codespaces", which will let you get started right away with [`dapr init`](https://docs.dapr.io/getting-started/install-dapr-selfhost/). The Codespace will be based off a personal fork of this repo (if you have not already forked this repo, one will be created for you), so feel free to explore!
+>Note GitHub Codespaces currently requires GitHub Team and Enterprise Cloud plans plus configuration by organization owners.  See the [CodeSpaces FAQ](https://github.com/features/codespaces) for current information on pre-reqs.  
 
 This repository is designed to help you explore different Dapr capabilities and you can go through the quickstarts based on the areas you would like to explore. Each quickstart includes sample code and a tutorial that will guide you through it.
 


### PR DESCRIPTION

Signed-off-by: Paul Yuknewicz <paulyuk@microsoft.com>

# Description

Update DevContainer base image to fix CodeSpaces and DevContainer issues

The biggest issue is #518 causing Codespace to crash and go into recovery mode. To fix, we change the base image pin in Dockerfile from `universal:1.6.9-focal` to `universal:1-focal` so we get updated 1.x semantic version but stop short of a possibly breaking 2.x release. The 1.6.9 focal image has the issue of running CodeSpaces out of storage during the Docker build (unpack) stages just on line 1 with the base image.  the later 1-focal does not have this issue. 

This has the side effect of fixing #499 since Dapr can properly initialize

Also per #501 we clarify required SKU of GH to see CodeSpaces so more users are successful.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #518, #499, #501

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
