### PR TITLE
Don't marshal the order string

### DIFF
--- a/service_invocation/go/http/README.md
+++ b/service_invocation/go/http/README.md
@@ -66,8 +66,8 @@ go build app.go
 <!-- STEP
 name: Run checkout service
 expected_stdout_lines:
-  - '== APP == Order passed:  "{\"orderId\":1}"'
-  - '== APP == Order passed:  "{\"orderId\":2}"'
+  - '== APP == Order passed:  {"orderId":1}'
+  - '== APP == Order passed:  {"orderId":2}'
   - "Exited App successfully"
 expected_stderr_lines:
 output_match_mode: substring

--- a/service_invocation/go/http/order-processor/app.go
+++ b/service_invocation/go/http/order-processor/app.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -16,11 +15,7 @@ func getOrder(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 	fmt.Println("Order received : ", string(data))
-	obj, err := json.Marshal(string(data))
-	if err != nil {
-		log.Println("Error in reading the result obj")
-	}
-	_, err = w.Write(obj)
+	_, err = w.Write(data)
 	if err != nil {
 		log.Println("Error in writing the result obj")
 	}


### PR DESCRIPTION
Don't marshal the order string because when we do we end up JSON-escaping
things which looks funky and inconsistent with the other samples

Signed-off-by: Doug Davis <dug@microsoft.com>