### PR TITLE
Update README.md

### DIFF
--- a/tutorials/hello-kubernetes/README.md
+++ b/tutorials/hello-kubernetes/README.md
@@ -15,7 +15,7 @@ Also, unless you have already done so, clone the repository with the quickstarts
 
 ```
 git clone [-b <dapr_version_tag>] https://github.com/dapr/quickstarts.git
-cd quickstarts/hello-kubernetes
+cd quickstarts/tutorials/hello-kubernetes
 ```
 
 > **Note**: See https://github.com/dapr/quickstarts#supported-dapr-runtime-version for supported tags. Use `git clone https://github.com/dapr/quickstarts.git` when using the edge version of dapr runtime.

--- a/tutorials/hello-world/README.md
+++ b/tutorials/hello-world/README.md
@@ -25,7 +25,7 @@ Now that Dapr is set up locally, clone the repo, then navigate to the Node.js ve
 
 ```sh
 git clone [-b <dapr_version_tag>] https://github.com/dapr/quickstarts.git
-cd quickstarts/hello-world/node
+cd quickstarts/tutorials/hello-world/node
 ```
 
 > **Note**: See https://github.com/dapr/quickstarts#supported-dapr-runtime-version for supported tags. Use `git clone https://github.com/dapr/quickstarts.git` when using the edge version of dapr runtime.

--- a/tutorials/observability/README.md
+++ b/tutorials/observability/README.md
@@ -32,7 +32,7 @@ spec:
 
 3. The applications launched with `dapr run` will by default reference the config file in `$HOME/.dapr/config.yaml` or `%USERPROFILE%\.dapr\config.yaml` and can be overridden with the Dapr CLI using the `--config` param. For example, the following command will launch the hello-world quickstart app using the default config.yaml:
 
-4. Clone this repo using `git clone [-b <dapr_version_tag>] https://github.com/dapr/quickstarts.git` and go to the repo's directory via `cd quickstarts/observability`.
+4. Clone this repo using `git clone [-b <dapr_version_tag>] https://github.com/dapr/quickstarts.git` and go to the repo's directory via `cd quickstarts/tutorials/observability`.
 
 <!-- STEP
 name: Run app with tracing


### PR DESCRIPTION
fixes path in documentation

# Description

Fixes folder path for README.md

## Issue reference

Please see #633

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
* [X] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
