### PR TITLE
Update Python pub_sub fastapi example

### DIFF
--- a/pub_sub/python/sdk/README.md
+++ b/pub_sub/python/sdk/README.md
@@ -41,9 +41,8 @@ background: true
 sleep: 10
 -->
 
-
 ```bash
-dapr run --app-id order-processor --components-path ../../../components/ --app-port 5001 -- python3 app.py
+dapr run --app-id order-processor --components-path ../../../components/ --app-port 5001 -- uvicorn app:app --port 5001
 ```
 
 <!-- END_STEP -->
@@ -76,7 +75,7 @@ working_dir: ./checkout
 background: true
 sleep: 10
 -->
-    
+
 ```bash
 dapr run --app-id checkout --components-path ../../../components/ -- python3 app.py
 ```

--- a/pub_sub/python/sdk/order-processor-fastapi/app.py
+++ b/pub_sub/python/sdk/order-processor-fastapi/app.py
@@ -1,12 +1,26 @@
-from fastapi import FastAPI
-# from cloudevents.http import from_http
 from dapr.ext.fastapi import DaprApp
+from fastapi import FastAPI
+from pydantic import BaseModel
 
 app = FastAPI()
 dapr_app = DaprApp(app)
 
 
+class CloudEvent(BaseModel):
+    datacontenttype: str
+    source: str
+    topic: str
+    pubsubname: str
+    data: dict
+    id: str
+    specversion: str
+    tracestate: str
+    type: str
+    traceid: str
+
+
 # Dapr subscription routes orders topic to this route
 @dapr_app.subscribe(pubsub='orderpubsub', topic='orders')
-def orders_subscriber(detail):
-    print('got here')
+def orders_subscriber(event: CloudEvent):
+    print('Subscriber received : %s' % event.data['orderId'], flush=True)
+    return {'success': True}

--- a/pub_sub/python/sdk/order-processor-fastapi/requirements.txt
+++ b/pub_sub/python/sdk/order-processor-fastapi/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 dapr-ext-fastapi==1.5.0
 cloudevents
+uvicorn

--- a/pub_sub/python/sdk/order-processor/requirements.txt
+++ b/pub_sub/python/sdk/order-processor/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 dapr
 cloudevents
+uvicorn


### PR DESCRIPTION
Signed-off-by: Michał Klich <michal@klichx.dev>

# Description

I have updated FastAPI example attached to `pub_sub` for Python.
It had not worked correctly.

## Issue reference

Sorry, but there is no issue.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
