### PR TITLE
Change order_pub_sub to orderpubsub

### DIFF
--- a/pub_sub/Commands
+++ b/pub_sub/Commands
@@ -5,7 +5,7 @@ And then modify the dapr run command to include components directory path using 
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: order_pub_sub
+  name: orderpubsub
 spec:
   type: pubsub.rabbitmq
   version: v1

--- a/pub_sub/components/pubsub.yaml
+++ b/pub_sub/components/pubsub.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: order_pub_sub
+  name: orderpubsub
 spec:
   type: pubsub.redis
   version: v1

--- a/pub_sub/csharp/http/checkout/Program.cs
+++ b/pub_sub/csharp/http/checkout/Program.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 var baseURL = (Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost") + ":" + (Environment.GetEnvironmentVariable("DAPR_HTTP_PORT") ?? "3500"); //reconfigure cpde to make requests to Dapr sidecar
-const string PUBSUBNAME = "order_pub_sub";
+const string PUBSUBNAME = "orderpubsub";
 const string TOPIC = "orders";
 Console.WriteLine($"Publishing to baseURL: {baseURL}, Pubsub Name: {PUBSUBNAME}, Topic: {TOPIC} ");
 

--- a/pub_sub/csharp/http/order-processor/Program.cs
+++ b/pub_sub/csharp/http/order-processor/Program.cs
@@ -8,7 +8,7 @@ if (app.Environment.IsDevelopment()) {app.UseDeveloperExceptionPage();}
 
 // Register Dapr pub/sub subscriptions
 app.MapGet("/dapr/subscribe", () => {
-    var sub = new DaprSubscription(PubsubName: "order_pub_sub", Topic: "orders", Route: "orders");
+    var sub = new DaprSubscription(PubsubName: "orderpubsub", Topic: "orders", Route: "orders");
     Console.WriteLine("Dapr pub/sub is subscribed to: " + sub);
     return Results.Json(new DaprSubscription[]{sub});
 });

--- a/pub_sub/csharp/sdk/checkout/Program.cs
+++ b/pub_sub/csharp/sdk/checkout/Program.cs
@@ -8,7 +8,7 @@ for (int i = 1; i <= 10; i++) {
     using var client = new DaprClientBuilder().Build();
 
     // Publish an event/message using Dapr PubSub
-    await client.PublishEventAsync("order_pub_sub", "orders", order);
+    await client.PublishEventAsync("orderpubsub", "orders", order);
     Console.WriteLine("Published data: " + order);
 
     await Task.Delay(TimeSpan.FromSeconds(1));

--- a/pub_sub/csharp/sdk/order-processor/Program.cs
+++ b/pub_sub/csharp/sdk/order-processor/Program.cs
@@ -14,7 +14,7 @@ app.MapSubscribeHandler();
 if (app.Environment.IsDevelopment()) {app.UseDeveloperExceptionPage();}
 
 // Dapr subscription in [Topic] routes orders topic to this route
-app.MapPost("/orders", [Topic("order_pub_sub", "orders")] (Order order) => {
+app.MapPost("/orders", [Topic("orderpubsub", "orders")] (Order order) => {
     Console.WriteLine("Subscriber received : " + order);
     return Results.Ok(order);
 });

--- a/pub_sub/go/http/checkout/app.go
+++ b/pub_sub/go/http/checkout/app.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const PUBSUB_NAME = "order_pub_sub"
+const PUBSUB_NAME = "orderpubsub"
 const PUBSUB_TOPIC = "orders"
 
 func main() {

--- a/pub_sub/go/http/order-processor/app.go
+++ b/pub_sub/go/http/order-processor/app.go
@@ -23,7 +23,7 @@ type Result struct {
 func getOrder(w http.ResponseWriter, r *http.Request) {
 	jsonData := []JSONObj{
 		{
-			PubsubName: "order_pub_sub",
+			PubsubName: "orderpubsub",
 			Topic:      "orders",
 			Route:      "orders",
 		},

--- a/pub_sub/go/sdk/checkout/app.go
+++ b/pub_sub/go/sdk/checkout/app.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	PUBSUB_NAME  = "order_pub_sub"
+	PUBSUB_NAME  = "orderpubsub"
 	PUBSUB_TOPIC = "orders"
 )
 

--- a/pub_sub/go/sdk/order-processor/app.go
+++ b/pub_sub/go/sdk/order-processor/app.go
@@ -12,7 +12,7 @@ import (
 )
 
 var sub = &common.Subscription{
-	PubsubName: "order_pub_sub",
+	PubsubName: "orderpubsub",
 	Topic:      "orders",
 	Route:      "orders",
 }

--- a/pub_sub/java/http/checkout/src/main/java/com/service/CheckoutServiceApplication.java
+++ b/pub_sub/java/http/checkout/src/main/java/com/service/CheckoutServiceApplication.java
@@ -19,7 +19,7 @@ public class CheckoutServiceApplication {
 			.connectTimeout(Duration.ofSeconds(10))
 			.build();
 
-	private static final String PUBSUB_NAME = "order_pub_sub";
+	private static final String PUBSUB_NAME = "orderpubsub";
 	private static final String TOPIC = "orders";
 	private static String DAPR_HOST = System.getenv().getOrDefault("DAPR_HOST", "http://localhost");
 	private static String DAPR_HTTP_PORT = System.getenv().getOrDefault("DAPR_HTTP_PORT", "3500");

--- a/pub_sub/java/http/order-processor/src/main/java/com/service/controller/OrderProcessingServiceController.java
+++ b/pub_sub/java/http/order-processor/src/main/java/com/service/controller/OrderProcessingServiceController.java
@@ -24,11 +24,11 @@ public class OrderProcessingServiceController {
     @GetMapping(path = "/dapr/subscribe", produces = MediaType.APPLICATION_JSON_VALUE)
     public DaprSubscription[] getSubscription() {
         DaprSubscription daprSubscription = DaprSubscription.builder()
-                .pubSubName("order_pub_sub")
+                .pubSubName("orderpubsub")
                 .topic("orders")
                 .route("orders")
                 .build();
-        logger.info("Subscribed to Pubsubname {} and topic {}", "order_pub_sub", "orders");
+        logger.info("Subscribed to Pubsubname {} and topic {}", "orderpubsub", "orders");
         DaprSubscription[] arr = new DaprSubscription[]{daprSubscription};
         return arr;
     }

--- a/pub_sub/java/sdk/checkout/src/main/java/com/service/CheckoutServiceApplication.java
+++ b/pub_sub/java/sdk/checkout/src/main/java/com/service/CheckoutServiceApplication.java
@@ -13,7 +13,7 @@ public class CheckoutServiceApplication {
 
 	public static void main(String[] args) throws InterruptedException{
 		String TOPIC_NAME = "orders";
-		String PUBSUB_NAME = "order_pub_sub";
+		String PUBSUB_NAME = "orderpubsub";
 
 		for (int i = 0; i <= 10; i++) {
 			int orderId = i;

--- a/pub_sub/java/sdk/order-processor/src/main/java/com/service/controller/OrderProcessingServiceController.java
+++ b/pub_sub/java/sdk/order-processor/src/main/java/com/service/controller/OrderProcessingServiceController.java
@@ -19,7 +19,7 @@ public class OrderProcessingServiceController {
 
     private static final Logger logger = LoggerFactory.getLogger(OrderProcessingServiceController.class);
 
-    @Topic(name = "orders", pubsubName = "order_pub_sub")
+    @Topic(name = "orders", pubsubName = "orderpubsub")
     @PostMapping(path = "/orders", consumes = MediaType.ALL_VALUE)
     public Mono<ResponseEntity> getCheckout(@RequestBody(required = false) CloudEvent<Order> cloudEvent) {
         return Mono.fromSupplier(() -> {

--- a/pub_sub/javascript/http/checkout/index.js
+++ b/pub_sub/javascript/http/checkout/index.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const DAPR_HOST = process.env.DAPR_HOST || "http://localhost";
 const DAPR_HTTP_PORT = process.env.DAPR_HTTP_PORT || "3500";
-const PUBSUB_NAME = "order_pub_sub";
+const PUBSUB_NAME = "orderpubsub";
 const PUBSUB_TOPIC = "orders";
 
 async function main() {

--- a/pub_sub/javascript/http/order-processor/index.js
+++ b/pub_sub/javascript/http/order-processor/index.js
@@ -7,7 +7,7 @@ app.use(bodyParser.json({ type: 'application/*+json' }));
 app.get('/dapr/subscribe', (_req, res) => {
     res.json([
         {
-            pubsubname: "order_pub_sub",
+            pubsubname: "orderpubsub",
             topic: "orders",
             route: "orders"
         }

--- a/pub_sub/javascript/sdk/checkout/index.js
+++ b/pub_sub/javascript/sdk/checkout/index.js
@@ -2,7 +2,7 @@ import { DaprClient } from 'dapr-client';
 
 const DAPR_HOST = process.env.DAPR_HOST || "http://localhost";
 const DAPR_HTTP_PORT = process.env.DAPR_HTTP_PORT || "3500";
-const PUBSUB_NAME = "order_pub_sub";
+const PUBSUB_NAME = "orderpubsub";
 const PUBSUB_TOPIC = "orders";
 
 async function main() {

--- a/pub_sub/javascript/sdk/order-processor/index.js
+++ b/pub_sub/javascript/sdk/order-processor/index.js
@@ -9,7 +9,7 @@ async function main() {
   const server = new DaprServer(SERVER_HOST, SERVER_PORT, DAPR_HOST, DAPR_HTTP_PORT);
 
   // Dapr subscription routes orders topic to this route
-  server.pubsub.subscribe("order_pub_sub", "orders", (data) => console.log("Subscriber received: " + JSON.stringify(data)));
+  server.pubsub.subscribe("orderpubsub", "orders", (data) => console.log("Subscriber received: " + JSON.stringify(data)));
 
   await server.start();
 }

--- a/pub_sub/python/http/checkout/app.py
+++ b/pub_sub/python/http/checkout/app.py
@@ -9,7 +9,7 @@ logging.basicConfig(level=logging.INFO)
 
 base_url = os.getenv('BASE_URL', 'http://localhost') + ':' + os.getenv(
                     'DAPR_HTTP_PORT', '3500')
-PUBSUB_NAME = 'order_pub_sub'
+PUBSUB_NAME = 'orderpubsub'
 TOPIC = 'orders'
 logging.info('Publishing to baseURL: %s, Pubsub Name: %s, Topic: %s' % (
             base_url, PUBSUB_NAME, TOPIC))

--- a/pub_sub/python/http/order-processor/app.py
+++ b/pub_sub/python/http/order-processor/app.py
@@ -3,12 +3,11 @@ import json
 
 app = Flask(__name__)
 
-
 # Register Dapr pub/sub subscriptions
 @app.route('/dapr/subscribe', methods=['GET'])
 def subscribe():
     subscriptions = [{
-        'pubsubname': 'order_pub_sub',
+        'pubsubname': 'orderpubsub',
         'topic': 'orders',
         'route': 'orders'
     }]

--- a/pub_sub/python/sdk/checkout/app.py
+++ b/pub_sub/python/sdk/checkout/app.py
@@ -11,7 +11,7 @@ for i in range(1, 10):
     with DaprClient() as client:
         # Publish an event/message using Dapr PubSub
         result = client.publish_event(
-            pubsub_name='order_pub_sub',
+            pubsub_name='orderpubsub',
             topic_name='orders',
             data=json.dumps(order),
             data_content_type='application/json',

--- a/pub_sub/python/sdk/order-processor-fastapi/app.py
+++ b/pub_sub/python/sdk/order-processor-fastapi/app.py
@@ -7,6 +7,6 @@ dapr_app = DaprApp(app)
 
 
 # Dapr subscription routes orders topic to this route
-@dapr_app.subscribe(pubsub='order_pub_sub', topic='orders')
+@dapr_app.subscribe(pubsub='orderpubsub', topic='orders')
 def orders_subscriber(detail):
     print('got here')

--- a/pub_sub/python/sdk/order-processor/app.py
+++ b/pub_sub/python/sdk/order-processor/app.py
@@ -9,7 +9,7 @@ app = Flask(__name__)
 @app.route('/dapr/subscribe', methods=['GET'])
 def subscribe():
     subscriptions = [{
-        'pubsubname': 'order_pub_sub',
+        'pubsubname': 'orderpubsub',
         'topic': 'orders',
         'route': 'orders'
     }]


### PR DESCRIPTION
Applying the pub/sub component to Kubernetes results in the following error: 

```
The Component "order_pub_sub" is invalid: metadata.name: Invalid value: "order_pub_sub": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

This PR fixes the component name to be compliant with RFC 1123 .
