### PR TITLE
-app-port for listen port, mm installation

### DIFF
--- a/pub_sub/go/sdk/order-processor/app.go
+++ b/pub_sub/go/sdk/order-processor/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/dapr/go-sdk/service/common"
 	daprd "github.com/dapr/go-sdk/service/http"
@@ -18,7 +19,15 @@ var sub = &common.Subscription{
 }
 
 func main() {
-	s := daprd.NewService(":6001")
+	// read app-port passed through 'dapr run' command line
+	// Refer to https://docs.dapr.io/reference/cli/dapr-run/
+	// for dapr flags and their corresponding environment variables
+	appPort, isSet := os.LookupEnv("APP_PORT")
+	if !isSet {
+		log.Fatalf("--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://docs.dapr.io/getting-started/quickstarts/pubsub-quickstart/\n")
+	}
+
+	s := daprd.NewService(":" + appPort)
 	http.HandleFunc("/orders", handleRequest)
 	if err := s.AddTopicEventHandler(sub, eventHandler); err != nil {
 		log.Fatalf("error adding topic subscription: %v", err)

--- a/validate.mk
+++ b/validate.mk
@@ -1,5 +1,10 @@
 
 MM_SHELL ?= bash -c
 
+all: install_mm validate
+
 validate:
 	mm.py -l -s "${MM_SHELL}" README.md
+
+install_mm:
+	type mm.py || sudo pip install mechanical-markdown


### PR DESCRIPTION
- Update order_processor to listen on -app-port vs. hardcoded port number of 6001. This hardwiring requires the documentation to be updated every time the port changes. Currently, the port used and the documentation are out of sync. By moving to listening on -app-port, order-processor can be run successfully irrespective of the port specified by the user.
- Since quickstarts are for folks bootstrapping on Dapr it is good to automate dependency setup. To run **make** in quickstarts, **mechanical_markdown** is a hard dependency. This is not clearly documented and hence make fails. Updated validate.mk to install **mechanical_markdown** in case it is not already installed.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_656_

##Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
