### PR TITLE
Updated the docker file to use linux arm image

### DIFF
--- a/tutorials/pub-sub/csharp-subscriber/Dockerfile
+++ b/tutorials/pub-sub/csharp-subscriber/Dockerfile
@@ -1,19 +1,19 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal-arm32v7 AS base
 WORKDIR /app
 EXPOSE 5009
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
 WORKDIR /src
 COPY ["csharp-subscriber.csproj", "./"]
-RUN dotnet restore "csharp-subscriber.csproj"
+RUN dotnet restore "csharp-subscriber.csproj" -r linux-arm
 COPY . .
 WORKDIR "/src/."
-RUN dotnet build "csharp-subscriber.csproj" -c Release -o /app/build
+RUN dotnet build "csharp-subscriber.csproj" -c Release -o /app/build -r linux-arm --self-contained false --no-restore
 
 FROM build AS publish
-RUN dotnet publish "csharp-subscriber.csproj" -c Release -o /app/publish
+RUN dotnet publish "csharp-subscriber.csproj" -c Release -o /app/publish -r linux-arm --self-contained false --no-restore
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
Signed-off-by: Arash Rohani <Arash.Rohani@gmail.com>

# Description

Updated the C# subscriber docker file to use linux arm image.
Hey @paulyuk It seems that there is one issue with regards to building image for C# in linux arm environment, I found a workaround and made the necessary changes accordingly, would you please merge this with master to test?

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).