### PR TITLE
Revert "Updated the docker file to use linux arm image"

### DIFF
--- a/tutorials/pub-sub/csharp-subscriber/Dockerfile
+++ b/tutorials/pub-sub/csharp-subscriber/Dockerfile
@@ -1,19 +1,19 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal-arm32v7 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 5009
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY ["csharp-subscriber.csproj", "./"]
-RUN dotnet restore "csharp-subscriber.csproj" -r linux-arm
+RUN dotnet restore "csharp-subscriber.csproj"
 COPY . .
 WORKDIR "/src/."
-RUN dotnet build "csharp-subscriber.csproj" -c Release -o /app/build -r linux-arm --self-contained false --no-restore
+RUN dotnet build "csharp-subscriber.csproj" -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "csharp-subscriber.csproj" -c Release -o /app/publish -r linux-arm --self-contained false --no-restore
+RUN dotnet publish "csharp-subscriber.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
Reverts dapr/quickstarts#672

As was my worry this hard codes a dockerfile that works for arm, but then breaks AMD:

`image with reference sha256:dbaa06bac17527126cb61a17b4bacf8da3b5c65042ad867cb7492c5755897a03 was found but does not match the specified platform: wanted linux/amd64, actual: linux/arm/v7`