### PR TITLE
Fix quickstarts to use app-port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ packages
 
 # macOS
 .DS_Store
+pub_sub/go/http/checkout/app
+pub_sub/go/http/order-processor/app
+pub_sub/javascript/http/order-processor/package-lock.json
+pub_sub/javascript/http/checkout/package-lock.json
+tutorials/bindings/nodeapp/package-lock.json
+tutorials/distributed-calculator/react-calculator/package-lock.json
+tutorials/distributed-calculator/react-calculator/client/package-lock.json

--- a/pub_sub/go/http/order-processor/app.go
+++ b/pub_sub/go/http/order-processor/app.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gorilla/mux"
 )
@@ -60,6 +61,11 @@ func postOrder(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	APP_PORT, okPort := os.LookupEnv("APP_PORT")
+	if !okPort {
+		log.Fatalf("--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://docs.dapr.io/getting-started/quickstarts/pubsub-quickstart/\n")
+	}
+
 	r := mux.NewRouter()
 
 	r.HandleFunc("/dapr/subscribe", getOrder).Methods("GET")
@@ -67,7 +73,7 @@ func main() {
 	// Dapr subscription routes orders topic to this route
 	r.HandleFunc("/orders", postOrder).Methods("POST")
 
-	if err := http.ListenAndServe(":6002", r); err != nil {
+	if err := http.ListenAndServe(":"+APP_PORT, r); err != nil {
 		log.Panic(err)
 	}
 }

--- a/pub_sub/javascript/http/order-processor/index.js
+++ b/pub_sub/javascript/http/order-processor/index.js
@@ -1,6 +1,11 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 
+const APP_PORT = process.env.APP_PORT
+if(!APP_PORT) {
+    console.log('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://docs.dapr.io/getting-started/quickstarts/pubsub-quickstart/\n');
+    process.exit(1);
+}
 const app = express();
 app.use(bodyParser.json({ type: 'application/*+json' }));
 
@@ -20,4 +25,4 @@ app.post('/orders', (req, res) => {
     res.sendStatus(200);
 });
 
-app.listen(5001);
+app.listen(APP_PORT);

--- a/tutorials/bindings/nodeapp/app.js
+++ b/tutorials/bindings/nodeapp/app.js
@@ -13,12 +13,16 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
+const port = process.env.APP_PORT ;
+if(!port) {
+    console.error('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/bindings\n');
+    process.exit(1);
+}
+
 require('isomorphic-fetch');
 
 const app = express();
 app.use(bodyParser.json());
-
-const port = 3000;
 
 app.post('/sample-topic', (req, res) => {
     console.log("Hello from Kafka!");

--- a/tutorials/distributed-calculator/go/app.go
+++ b/tutorials/distributed-calculator/go/app.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gorilla/mux"
 )
@@ -32,13 +33,17 @@ func add(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	var operands Operands
 	json.NewDecoder(r.Body).Decode(&operands)
-	fmt.Println(fmt.Sprintf("%s%f%s%f", "Adding ", operands.OperandOne, " to ", operands.OperandTwo))
+	fmt.Printf("Adding %f to %f\n", operands.OperandOne, operands.OperandTwo)
 	json.NewEncoder(w).Encode(operands.OperandOne + operands.OperandTwo)
 }
 
 func main() {
+	appPort, isSet := os.LookupEnv("APP_PORT")
+	if !isSet {
+		log.Fatalf("--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/distributed-calculator\n")
+	}
 	router := mux.NewRouter()
 
 	router.HandleFunc("/add", add).Methods("POST", "OPTIONS")
-	log.Fatal(http.ListenAndServe(":6000", router))
+	log.Fatal(http.ListenAndServe(":"+appPort, router))
 }

--- a/tutorials/distributed-calculator/node/app.js
+++ b/tutorials/distributed-calculator/node/app.js
@@ -16,7 +16,11 @@ const bodyParser = require('body-parser');
 const app = express();
 app.use(bodyParser.json());
 const cors = require('cors');
-const port = 4000;
+const port = process.env.APP_PORT ;
+if(!port) {
+    console.error('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/distributed-calculator\n');
+    process.exit(1);
+}
 
 app.use(cors());
 

--- a/tutorials/distributed-calculator/python/app.py
+++ b/tutorials/distributed-calculator/python/app.py
@@ -16,6 +16,11 @@ from flask import request, jsonify
 from flask_cors import CORS
 import math
 import sys
+import os
+
+appPort = os.getenv("APP_PORT")
+if appPort is None:
+    raise EnvironmentError('--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/distributed-calculator\n')
 
 app = flask.Flask(__name__)
 CORS(app)
@@ -27,4 +32,4 @@ def multiply():
     print(f"Calculating {operand_one} * {operand_two}", flush=True)
     return jsonify(math.ceil(operand_one * operand_two * 100000)/100000)
 
-app.run(port=5001)
+app.run(port=appPort)

--- a/tutorials/hello-kubernetes/node/app.js
+++ b/tutorials/hello-kubernetes/node/app.js
@@ -24,7 +24,11 @@ const daprGRPCPort = process.env.DAPR_GRPC_PORT;
 
 const stateStoreName = `statestore`;
 const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
-const port = 3000;
+const port = process.env.APP_PORT ;
+if(!port) {
+    console.error('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/hello-kubernetes\n');
+    process.exit(1);
+}
 
 app.get('/order', async (_req, res) => {
     try {

--- a/tutorials/hello-world/node/app.js
+++ b/tutorials/hello-world/node/app.js
@@ -20,7 +20,11 @@ app.use(express.json());
 const daprPort = process.env.DAPR_HTTP_PORT || 3500;
 const stateStoreName = `statestore`;
 const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
-const port = 3000;
+const port = process.env.APP_PORT ;
+if(!port) {
+    console.error('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/hello-world\n');
+    process.exit(1);
+}
 
 app.get('/order', async (_req, res) => {
     try {

--- a/tutorials/observability/python/app.py
+++ b/tutorials/observability/python/app.py
@@ -17,6 +17,11 @@ from flask_cors import CORS
 import math
 import sys
 import time
+import os
+
+port = os.getenv("APP_PORT")
+if port is None:
+    raise EnvironmentError('--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/observability\n')
 
 app = flask.Flask(__name__)
 CORS(app)
@@ -32,4 +37,4 @@ def multiply():
     print(f"Calculating {operand_one} * {operand_two}", flush=True)
     return jsonify(math.ceil(operand_one * operand_two * 100000)/100000)
 
-app.run(port=5001)
+app.run(port)


### PR DESCRIPTION
Signed-off-by: akhilac1 <chetlapalle.akhila@gmail.com>

# Description

Updated quickstarts to use app_port passed on CLI via environment variable APP_PORT vs. hard coding the listening port in quickstarts.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #661 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [Y] The quickstart code compiles correctly
* [Y] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
* [X] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
