### PR TITLE
Fixing the broken link for dapr kubernetes installation

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -126,7 +126,7 @@ jobs:
           dapr --version
       - name: Install Dapr - Kubernetes
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add dapr https://dapr.github.io/helm-charts/
           helm repo update
           helm install redis bitnami/redis
           dapr init -k --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --wait || kubectl get pods --all-namespaces


### PR DESCRIPTION
Signed-off-by: Amulya Varote <amulyavarote@microsoft.com>

# Description

Build fix by fixing the link used to install dapr on kubernetes.

_Please explain the changes you've made_

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
