### PR TITLE
Sets APP_PORT in env var of kubernetes yaml and sets default value in…

### DIFF
--- a/tutorials/hello-kubernetes/deploy/node.yaml
+++ b/tutorials/hello-kubernetes/deploy/node.yaml
@@ -38,6 +38,9 @@ spec:
       containers:
       - name: node
         image: ghcr.io/dapr/samples/hello-k8s-node:latest
+        env:
+        - name: APP_PORT
+        value: "3000"
         ports:
         - containerPort: 3000
         imagePullPolicy: Always

--- a/tutorials/hello-kubernetes/deploy/node.yaml
+++ b/tutorials/hello-kubernetes/deploy/node.yaml
@@ -37,10 +37,10 @@ spec:
     spec:
       containers:
       - name: node
-        image: ghcr.io/dapr/samples/hello-k8s-node:latest
+        image: docker.io/paulyuk/quickstarts-nodeapp:latest
         env:
         - name: APP_PORT
-        value: "3000"
+          value: "3000"
         ports:
         - containerPort: 3000
         imagePullPolicy: Always

--- a/tutorials/hello-kubernetes/deploy/node.yaml
+++ b/tutorials/hello-kubernetes/deploy/node.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: node
-        image: docker.io/paulyuk/quickstarts-nodeapp:latest
+        image: ghcr.io/dapr/samples/hello-k8s-node:latest
         env:
         - name: APP_PORT
           value: "3000"

--- a/tutorials/hello-kubernetes/node/app.js
+++ b/tutorials/hello-kubernetes/node/app.js
@@ -19,16 +19,12 @@ const app = express();
 app.use(bodyParser.json());
 
 // These ports are injected automatically into the container.
-const daprPort = process.env.DAPR_HTTP_PORT; 
-const daprGRPCPort = process.env.DAPR_GRPC_PORT;
+const daprPort = process.env.DAPR_HTTP_PORT ?? "3500"; 
+const daprGRPCPort = process.env.DAPR_GRPC_PORT ?? "50001";
 
 const stateStoreName = `statestore`;
 const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
-const port = process.env.APP_PORT ;
-if(!port) {
-    console.error('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/hello-kubernetes\n');
-    process.exit(1);
-}
+const port = process.env.APP_PORT ?? "3000";
 
 app.get('/order', async (_req, res) => {
     try {


### PR DESCRIPTION
Sets APP_PORT environment variable for hello-kubernetes nodeapp in kubernetes yaml, and hardens code to set a default value if env var is not found.  Fixes #682

Signed-off-by: Paul Yuknewicz <paulyuk@microsoft.com>

# Description

_Please explain the changes you've made_

## Issue reference
Fixes #682

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
