### PR TITLE
#682 APP_PORT not injected into app container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,13 +36,7 @@ packages
 *.zip
 *.tar.gz
 *.rar
+*.package-lock.json
 
 # macOS
 .DS_Store
-pub_sub/go/http/checkout/app
-pub_sub/go/http/order-processor/app
-pub_sub/javascript/http/order-processor/package-lock.json
-pub_sub/javascript/http/checkout/package-lock.json
-tutorials/bindings/nodeapp/package-lock.json
-tutorials/distributed-calculator/react-calculator/package-lock.json
-tutorials/distributed-calculator/react-calculator/client/package-lock.json

--- a/pub_sub/go/http/order-processor/app.go
+++ b/pub_sub/go/http/order-processor/app.go
@@ -61,9 +61,9 @@ func postOrder(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	APP_PORT, okPort := os.LookupEnv("APP_PORT")
-	if !okPort {
-		log.Fatalf("--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://docs.dapr.io/getting-started/quickstarts/pubsub-quickstart/\n")
+	appPort := "6002"
+	if value, ok := os.LookupEnv("APP_PORT"); ok {
+		appPort = value
 	}
 
 	r := mux.NewRouter()
@@ -73,7 +73,7 @@ func main() {
 	// Dapr subscription routes orders topic to this route
 	r.HandleFunc("/orders", postOrder).Methods("POST")
 
-	if err := http.ListenAndServe(":"+APP_PORT, r); err != nil {
+	if err := http.ListenAndServe(":"+appPort, r); err != nil {
 		log.Panic(err)
 	}
 }

--- a/pub_sub/go/sdk/order-processor/app.go
+++ b/pub_sub/go/sdk/order-processor/app.go
@@ -18,12 +18,9 @@ var sub = &common.Subscription{
 }
 
 func main() {
-	// read app-port passed through 'dapr run' command line
-	// Refer to https://docs.dapr.io/reference/cli/dapr-run/
-	// for dapr flags and their corresponding environment variables
-	appPort, isSet := os.LookupEnv("APP_PORT")
-	if !isSet {
-		log.Fatalf("--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://docs.dapr.io/getting-started/quickstarts/pubsub-quickstart/\n")
+	appPort := "6001"
+	if value, ok := os.LookupEnv("APP_PORT"); ok {
+		appPort = value
 	}
 
 	s := daprd.NewService(":" + appPort)

--- a/pub_sub/javascript/http/order-processor/index.js
+++ b/pub_sub/javascript/http/order-processor/index.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 
-const APP_PORT = process.env.APP_PORT || 5001;
+const APP_PORT = process.env.APP_PORT ?? '5001';
 
 const app = express();
 app.use(bodyParser.json({ type: 'application/*+json' }));

--- a/pub_sub/javascript/http/order-processor/index.js
+++ b/pub_sub/javascript/http/order-processor/index.js
@@ -1,11 +1,8 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 
-const APP_PORT = process.env.APP_PORT
-if(!APP_PORT) {
-    console.log('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://docs.dapr.io/getting-started/quickstarts/pubsub-quickstart/\n');
-    process.exit(1);
-}
+const APP_PORT = process.env.APP_PORT || 5001;
+
 const app = express();
 app.use(bodyParser.json({ type: 'application/*+json' }));
 

--- a/tutorials/bindings/nodeapp/app.js
+++ b/tutorials/bindings/nodeapp/app.js
@@ -13,11 +13,7 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
-const port = process.env.APP_PORT ;
-if(!port) {
-    console.error('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/bindings\n');
-    process.exit(1);
-}
+const port = process.env.APP_PORT || 3000 ;
 
 require('isomorphic-fetch');
 

--- a/tutorials/bindings/nodeapp/app.js
+++ b/tutorials/bindings/nodeapp/app.js
@@ -13,7 +13,8 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
-const port = process.env.APP_PORT || 3000 ;
+const port = process.env.APP_PORT ?? '3000' ;
+
 
 require('isomorphic-fetch');
 

--- a/tutorials/distributed-calculator/deploy/go-adder.yaml
+++ b/tutorials/distributed-calculator/deploy/go-adder.yaml
@@ -22,6 +22,9 @@ spec:
       containers:
       - name: add
         image: ghcr.io/dapr/samples/distributed-calculator-go:latest
+        env:
+        - name: APP_PORT
+          value: "6000"
         ports:
         - containerPort: 6000
         imagePullPolicy: Always

--- a/tutorials/distributed-calculator/deploy/node-divider.yaml
+++ b/tutorials/distributed-calculator/deploy/node-divider.yaml
@@ -22,6 +22,9 @@ spec:
       containers:
       - name: divide
         image: ghcr.io/dapr/samples/distributed-calculator-node:latest
+        env:
+        - name: APP_PORT
+          value: "4000"
         ports:
         - containerPort: 4000
         imagePullPolicy: Always

--- a/tutorials/distributed-calculator/deploy/python-multiplier.yaml
+++ b/tutorials/distributed-calculator/deploy/python-multiplier.yaml
@@ -22,6 +22,9 @@ spec:
       containers:
       - name: multiply
         image: ghcr.io/dapr/samples/distributed-calculator-slow-python:latest
+        env:
+        - name: "APP_PORT"
+          value: "5001"
         ports:
         - containerPort: 5001
         imagePullPolicy: Always

--- a/tutorials/distributed-calculator/go/app.go
+++ b/tutorials/distributed-calculator/go/app.go
@@ -38,9 +38,9 @@ func add(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	appPort, isSet := os.LookupEnv("APP_PORT")
-	if !isSet {
-		log.Fatalf("--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/distributed-calculator\n")
+	appPort := "6000"
+	if value, ok := os.LookupEnv("APP_PORT"); ok {
+		appPort = value
 	}
 	router := mux.NewRouter()
 

--- a/tutorials/distributed-calculator/node/app.js
+++ b/tutorials/distributed-calculator/node/app.js
@@ -16,11 +16,7 @@ const bodyParser = require('body-parser');
 const app = express();
 app.use(bodyParser.json());
 const cors = require('cors');
-const port = process.env.APP_PORT ;
-if(!port) {
-    console.error('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/distributed-calculator\n');
-    process.exit(1);
-}
+const port = process.env.APP_PORT || 4000 ;
 
 app.use(cors());
 

--- a/tutorials/distributed-calculator/node/app.js
+++ b/tutorials/distributed-calculator/node/app.js
@@ -16,7 +16,7 @@ const bodyParser = require('body-parser');
 const app = express();
 app.use(bodyParser.json());
 const cors = require('cors');
-const port = process.env.APP_PORT || 4000 ;
+const port = process.env.APP_PORT ?? '4000';
 
 app.use(cors());
 

--- a/tutorials/distributed-calculator/python/app.py
+++ b/tutorials/distributed-calculator/python/app.py
@@ -18,9 +18,7 @@ import math
 import sys
 import os
 
-appPort = os.getenv("APP_PORT")
-if appPort is None:
-    raise EnvironmentError('--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/distributed-calculator\n')
+appPort = os.getenv("APP_PORT","5001")
 
 app = flask.Flask(__name__)
 CORS(app)

--- a/tutorials/distributed-calculator/python/app.py
+++ b/tutorials/distributed-calculator/python/app.py
@@ -30,4 +30,4 @@ def multiply():
     print(f"Calculating {operand_one} * {operand_two}", flush=True)
     return jsonify(math.ceil(operand_one * operand_two * 100000)/100000)
 
-app.run(port=appPort)
+app.run(host="0.0.0.0",port=appPort)

--- a/tutorials/hello-world/node/app.js
+++ b/tutorials/hello-world/node/app.js
@@ -20,7 +20,7 @@ app.use(express.json());
 const daprPort = process.env.DAPR_HTTP_PORT || 3500;
 const stateStoreName = `statestore`;
 const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
-const port = process.env.APP_PORT || 3000;
+const port = process.env.APP_PORT ?? '3000';
 
 app.get('/order', async (_req, res) => {
     try {

--- a/tutorials/hello-world/node/app.js
+++ b/tutorials/hello-world/node/app.js
@@ -20,11 +20,7 @@ app.use(express.json());
 const daprPort = process.env.DAPR_HTTP_PORT || 3500;
 const stateStoreName = `statestore`;
 const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
-const port = process.env.APP_PORT ;
-if(!port) {
-    console.error('[error]: --app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/hello-world\n');
-    process.exit(1);
-}
+const port = process.env.APP_PORT || 3000;
 
 app.get('/order', async (_req, res) => {
     try {

--- a/tutorials/observability/deploy/python-multiplier.yaml
+++ b/tutorials/observability/deploy/python-multiplier.yaml
@@ -25,8 +25,6 @@ spec:
         env:
         - name: APP_PORT
           value: "5001"
-        command: ["/bin/sh"]
-        args: ["-c","python3 app.py"]
         ports:
         - containerPort: 5001
         imagePullPolicy: Always

--- a/tutorials/observability/deploy/python-multiplier.yaml
+++ b/tutorials/observability/deploy/python-multiplier.yaml
@@ -22,6 +22,11 @@ spec:
       containers:
       - name: multiply
         image: ghcr.io/dapr/samples/distributed-calculator-slow-python:latest
+        env:
+        - name: APP_PORT
+          value: "5001"
+        command: ["/bin/sh"]
+        args: ["-c","python3 app.py"]
         ports:
         - containerPort: 5001
         imagePullPolicy: Always

--- a/tutorials/observability/python/Dockerfile
+++ b/tutorials/observability/python/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 RUN pip install flask flask_cors
 ENTRYPOINT ["python"]
 EXPOSE 5001
-CMD ["app.py"]
+CMD ["python3 app.py"]

--- a/tutorials/observability/python/Dockerfile
+++ b/tutorials/observability/python/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 RUN pip install flask flask_cors
 ENTRYPOINT ["python"]
 EXPOSE 5001
-CMD ["python3 app.py"]
+CMD ["app.py"]

--- a/tutorials/observability/python/app.py
+++ b/tutorials/observability/python/app.py
@@ -19,9 +19,7 @@ import sys
 import time
 import os
 
-port = os.getenv("APP_PORT")
-if port is None:
-    raise EnvironmentError('--app-port is not set. Re-run dapr run with -p or --app-port.\nUsage: https://github.com/dapr/quickstarts/tree/master/tutorials/observability\n')
+port = os.getenv("APP_PORT","5001")
 
 app = flask.Flask(__name__)
 CORS(app)
@@ -37,4 +35,4 @@ def multiply():
     print(f"Calculating {operand_one} * {operand_two}", flush=True)
     return jsonify(math.ceil(operand_one * operand_two * 100000)/100000)
 
-app.run(port)
+app.run(host="0.0.0.0",port=port)


### PR DESCRIPTION
Signed-off-by: akhilac1 <chetlapalle.akhila@gmail.com>

# Description

1. Added default value for APP_PORT in case it cannot be fetched from environment variables
2. Updated yaml to include addition of environment variable for APP_PORT [ until the dapr.io/app_port annotation issue is fixed #684  ]
3. Default command to run the app in observability quickstart ALWAYS uses port 5000. Updated quickstarts/tutorials/observability/python/Dockerfile to use python3 app.py as launch command and use specified port

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #682 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
