### PR TITLE
Removed the extra space in expected test result

### DIFF
--- a/tutorials/pub-sub/README.md
+++ b/tutorials/pub-sub/README.md
@@ -506,6 +506,8 @@ expected_stdout_lines:
   - "A: Message on A"
   - "B: Message on B"
   - "C: Message on C"
+expected_stderr_lines:
+output_match_mode: substring
 -->
 
 ```bash

--- a/tutorials/pub-sub/README.md
+++ b/tutorials/pub-sub/README.md
@@ -503,9 +503,9 @@ kubectl logs --selector app=python-subscriber -c python-subscriber
 <!-- STEP
 name: Deploy Csharp App
 expected_stdout_lines:
-  - "A:  Message on A"
-  - "B:  Message on B"
-  - "C:  Message on C"
+  - "A: Message on A"
+  - "B: Message on B"
+  - "C: Message on C"
 -->
 
 ```bash

--- a/tutorials/pub-sub/README.md
+++ b/tutorials/pub-sub/README.md
@@ -167,9 +167,9 @@ dotnet build
 name: Run csharp subscriber
 expected_stdout_lines:
   - "You're up and running! Both Dapr and your app logs will appear here."
-  - '== APP ==       A: Message on A'
-  - '== APP ==       B: Message on B'
-  - '== APP ==       C: Message on C'
+  - '== APP == A: Message on A'
+  - '== APP == B: Message on B'
+  - '== APP == C: Message on C'
   - "Exited Dapr successfully"
   - "Exited App successfully"
 expected_stderr_lines:
@@ -508,6 +508,7 @@ expected_stdout_lines:
   - "C: Message on C"
 expected_stderr_lines:
 output_match_mode: substring
+sleep: 5
 -->
 
 ```bash

--- a/tutorials/pub-sub/csharp-subscriber/Program.cs
+++ b/tutorials/pub-sub/csharp-subscriber/Program.cs
@@ -10,17 +10,17 @@ app.UseCloudEvents();
 app.MapSubscribeHandler();
 
 app.MapPost("/A", [Topic("pubsub", "A")] (ILogger<Program> logger, MessageEvent item) => {
-    logger.LogInformation($"{item.MessageType}: {item.Message}");
+    Console.WriteLine($"{item.MessageType}: {item.Message}");
     return Results.Ok();
 });
 
 app.MapPost("/B", [Topic("pubsub", "B")] (ILogger<Program> logger, MessageEvent item) => {
-    logger.LogInformation($"{item.MessageType}: {item.Message}");
+    Console.WriteLine($"{item.MessageType}: {item.Message}");
     return Results.Ok();
 });
 
 app.MapPost("/C", [Topic("pubsub", "C")] (ILogger<Program> logger, Dictionary<string, string> item) => {
-    logger.LogInformation($"{item["messageType"]}: {item["message"]}");
+    Console.WriteLine($"{item["messageType"]}: {item["message"]}");
     return Results.Ok();
 });
 


### PR DESCRIPTION
Signed-off-by: Arash Rohani <Arash.Rohani@gmail.com>

# Description

Removed the extra space in expected test result to fix the test workflow.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).