### PR TITLE
Fix for failing Auto validate Java examples on State management

### DIFF
--- a/.github/workflows/validate_new_quickstarts_state_management.yaml
+++ b/.github/workflows/validate_new_quickstarts_state_management.yaml
@@ -109,16 +109,16 @@ jobs:
           pushd state_management/javascript/sdk
           make validate
           popd
-      # - name: Validate Java http State Management
-      #   run: |
-      #     pushd state_management/java/http
-      #     make validate
-      #     popd
-      # - name: Validate Java sdk State Management
-      #   run: |
-      #     pushd state_management/java/sdk
-      #     make validate
-      #     popd
+      - name: Validate Java http State Management
+        run: |
+          pushd state_management/java/http
+          make validate
+          popd
+      - name: Validate Java sdk State Management
+        run: |
+          pushd state_management/java/sdk
+          make validate
+          popd
       - name: Validate Go http State Management
         run: |
           pushd state_management/go/http

--- a/state_management/java/http/README.md
+++ b/state_management/java/http/README.md
@@ -38,8 +38,10 @@ mvn clean install
 <!-- STEP
 name: Run order-processor service
 expected_stdout_lines:
-  - '== APP == Getting Order:  "{\"orderId\":1}"'
-  - '== APP == Getting Order:  "{\"orderId\":2}"'
+  - '== APP == Saving order: 1'
+  - '== APP == Order saved: {"orderId":1}'
+  - '== APP == Deleting order: 1'
+  - '== APP == Deletion Status code :204'
   - "Exited App successfully"
 expected_stderr_lines:
 output_match_mode: substring

--- a/state_management/java/http/order-processor/pom.xml
+++ b/state_management/java/http/order-processor/pom.xml
@@ -14,16 +14,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4jVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4jVersion}</version>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.16</version>

--- a/state_management/java/http/order-processor/src/main/java/com/service/OrderProcessingServiceApplication.java
+++ b/state_management/java/http/order-processor/src/main/java/com/service/OrderProcessingServiceApplication.java
@@ -3,8 +3,6 @@ package com.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -16,8 +14,6 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 public class OrderProcessingServiceApplication {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OrderProcessingServiceApplication.class);
-
     private static final String DAPR_STATE_STORE = "statestore";
     private static String DAPR_HOST = System.getenv().getOrDefault("DAPR_HOST", "http://localhost");
     private static String DAPR_HTTP_PORT = System.getenv().getOrDefault("DAPR_HTTP_PORT", "3500");
@@ -42,7 +38,7 @@ public class OrderProcessingServiceApplication {
                     .uri(stateStoreUrl)
                     .build();
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            LOGGER.info("Saving order: "+ order.getOrderId());
+            System.out.println("Saving order: "+ order.getOrderId());
 
             // Get state from a state store
             URI getStateURL = new URI(baseUrl + "/v1.0/state/"+DAPR_STATE_STORE+"/"+String.valueOf(orderId));
@@ -52,7 +48,7 @@ public class OrderProcessingServiceApplication {
                     .build();
 
             response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            LOGGER.info("Order saved: "+ response.body());
+            System.out.println("Order saved: "+ response.body());
 
             // Delete state from the state store
             URI deleteStateURI = new URI(baseUrl + "/v1.0/state/" + DAPR_STATE_STORE + "/" + String.valueOf(orderId));
@@ -61,8 +57,8 @@ public class OrderProcessingServiceApplication {
                     .uri(deleteStateURI)
                     .build();
             response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            LOGGER.info("Deleting order: "+ order.getOrderId());
-            LOGGER.info("Deletion Status code :"+ response.statusCode());
+            System.out.println("Deleting order: "+ order.getOrderId());
+            System.out.println("Deletion Status code :"+ response.statusCode());
             TimeUnit.MILLISECONDS.sleep(1000);
         }
     }

--- a/state_management/java/sdk/README.md
+++ b/state_management/java/sdk/README.md
@@ -38,8 +38,9 @@ mvn clean install
 <!-- STEP
 name: Run order-processor service
 expected_stdout_lines:
-  - '== APP == Getting Order:  "{\"orderId\":1}"'
-  - '== APP == Getting Order:  "{\"orderId\":2}"'
+  - "== APP == Saving Order: 1"
+  - '== APP == Getting Order: 1'
+  - '== APP == Deleting Order: 1'
   - "Exited App successfully"
 expected_stderr_lines:
 output_match_mode: substring

--- a/state_management/java/sdk/order-processor/pom.xml
+++ b/state_management/java/sdk/order-processor/pom.xml
@@ -18,16 +18,6 @@
             <version>1.4.0</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4jVersion}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4jVersion}</version>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.16</version>

--- a/state_management/java/sdk/order-processor/src/main/java/com/service/OrderProcessingServiceApplication.java
+++ b/state_management/java/sdk/order-processor/src/main/java/com/service/OrderProcessingServiceApplication.java
@@ -5,12 +5,9 @@ import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.State;
 import lombok.Getter;
 import lombok.Setter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.util.concurrent.TimeUnit;
 
 public class OrderProcessingServiceApplication {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OrderProcessingServiceApplication.class);
     private static final String DAPR_STATE_STORE = "statestore";
 
     public static void main(String[] args) throws Exception {
@@ -22,15 +19,15 @@ public class OrderProcessingServiceApplication {
 
                 // Save state into the state store
                 client.saveState(DAPR_STATE_STORE, String.valueOf(orderId), order).block();
-                LOGGER.info("Saving Order: " + order.getOrderId());
+                System.out.println("Saving Order: " + order.getOrderId());
 
                 // Get state from the state store
                 State<Order> response = client.getState(DAPR_STATE_STORE, String.valueOf(orderId), Order.class).block();
-                LOGGER.info("Getting Order: " + response.getValue().getOrderId());
+                System.out.println("Getting Order: " + response.getValue().getOrderId());
 
                 // Delete state from the state store
                 client.deleteState(DAPR_STATE_STORE, String.valueOf(orderId)).block();
-                LOGGER.info("Deleting Order: " + orderId);
+                System.out.println("Deleting Order: " + orderId);
                 TimeUnit.MILLISECONDS.sleep(1000);
             }
         }


### PR DESCRIPTION
# Description

- Fix for failing state management java auto validate quickstarts
- Removed Logger and related dependencies as it creates random Id with each log stmt which markdown is not able to validate. Other java examples also follow the same way.


## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
