### PR TITLE
Fix CodeSpace failure for quickstarts repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,22 +11,4 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/vscode/devcontainers/universal:1-focal
-
-# Copy custom first notice message.
-COPY first-run-notice.txt /tmp/staging/
-RUN sudo mv -f /tmp/staging/first-run-notice.txt /usr/local/etc/vscode-dev-containers/ \
-    && sudo rm -rf /tmp/staging
-
-# Install minikube
-RUN MINIKUBE_URL="https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64" \
-    && sudo curl -sSL -o /usr/local/bin/minikube "${MINIKUBE_URL}" \
-    && sudo chmod 0755 /usr/local/bin/minikube \
-    && MINIKUBE_SHA256=$(curl -sSL "${MINIKUBE_URL}.sha256") \
-    && echo "${MINIKUBE_SHA256} */usr/local/bin/minikube" | sha256sum -c -
-
-# Install Dapr CLI
-RUN wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash
-
-# Install mechanical-markdown for quickstart validations
-RUN pip install mechanical-markdown
+FROM paulyuk/daprquickstarts:latest

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,21 @@
 #
 
 FROM mcr.microsoft.com/vscode/devcontainers/universal:focal
+
+# Copy custom first notice message.
+COPY first-run-notice.txt /tmp/staging/
+RUN sudo mv -f /tmp/staging/first-run-notice.txt /usr/local/etc/vscode-dev-containers/ \
+    && sudo rm -rf /tmp/staging
+
+# Install minikube
+RUN MINIKUBE_URL="https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64" \
+    && sudo curl -sSL -o /usr/local/bin/minikube "${MINIKUBE_URL}" \
+    && sudo chmod 0755 /usr/local/bin/minikube \
+    && MINIKUBE_SHA256=$(curl -sSL "${MINIKUBE_URL}.sha256") \
+    && echo "${MINIKUBE_SHA256} */usr/local/bin/minikube" | sha256sum -c -
+
+# Install Dapr CLI
+RUN wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash
+
+# Install mechanical-markdown for quickstart validations
+RUN pip install mechanical-markdown

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,4 +11,4 @@
 # limitations under the License.
 #
 
-FROM paulyuk/daprquickstarts:latest
+FROM http://mcr.microsoft.com/vscode/devcontainers/universal:focal

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-FROM mcr.microsoft.com/vscode/devcontainers/universal:focal
+FROM mcr.microsoft.com/vscode/devcontainers/universal:latest
 
 # Copy custom first notice message.
 COPY first-run-notice.txt /tmp/staging/

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,4 +11,4 @@
 # limitations under the License.
 #
 
-FROM http://mcr.microsoft.com/vscode/devcontainers/universal:focal
+FROM mcr.microsoft.com/vscode/devcontainers/universal:focal


### PR DESCRIPTION
# Description

Changes the base image for codespaces from universal:focal (and a pinned version) to universal:latest (which is already cached in codespaces).  This overcomes the issue of the large image pull exceeding the docker layer cache storage limit of the codespace.  

## Issue reference

fixes #691 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
