### PR TITLE
Updated lombok version to 1.18.22

### DIFF
--- a/state_management/java/sdk/order-processor/pom.xml
+++ b/state_management/java/sdk/order-processor/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.22</version>
             <optional>true</optional>
         </dependency>
     </dependencies>


### PR DESCRIPTION
# Description

Bumps lombok version from 1.18.16 to 1.18.22
Older version is not aligned with other quickstarts and fail to compile with Java 17

 
