### PR TITLE
Enabling python pubsub quickstart validation

### DIFF
--- a/.github/workflows/validate_new_quickstarts_pubsub.yaml
+++ b/.github/workflows/validate_new_quickstarts_pubsub.yaml
@@ -109,16 +109,16 @@ jobs:
           pushd pub_sub/javascript/sdk
           make validate
           popd
-      # - name: Validate python http pubsub
-      #   run: |
-      #     pushd pub_sub/python/http
-      #     make validate
-      #     popd
-      # - name: Validate python sdk pubsub
-      #   run: |
-      #     pushd pub_sub/python/sdk
-      #     make validate
-      #     popd
+      - name: Validate python http pubsub
+        run: |
+          pushd pub_sub/python/http
+          make validate
+          popd
+      - name: Validate python sdk pubsub
+        run: |
+          pushd pub_sub/python/sdk
+          make validate
+          popd
       - name: Validate java http pubsub
         run: |
           pushd pub_sub/java/http


### PR DESCRIPTION
# Description

Enable the python pubsub workflow validation.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
