### PR TITLE
Fix maven dependency incompatible with Java 11

### DIFF
--- a/secrets_management/java/http/order-processor/pom.xml
+++ b/secrets_management/java/http/order-processor/pom.xml
@@ -21,6 +21,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.6.3</version>
                 <executions>
                     <execution>
                         <goals>

--- a/secrets_management/java/sdk/order-processor/pom.xml
+++ b/secrets_management/java/sdk/order-processor/pom.xml
@@ -28,6 +28,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.6.3</version>
                 <executions>
                     <execution>
                         <goals>

--- a/service_invocation/java/http/checkout/pom.xml
+++ b/service_invocation/java/http/checkout/pom.xml
@@ -25,6 +25,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>2.6.3</version>
 				<executions>
 					<execution>
 						<goals>

--- a/state_management/java/http/order-processor/pom.xml
+++ b/state_management/java/http/order-processor/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.24</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -32,6 +32,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.6.3</version>
                 <executions>
                     <execution>
                         <goals>

--- a/state_management/java/sdk/order-processor/pom.xml
+++ b/state_management/java/sdk/order-processor/pom.xml
@@ -32,6 +32,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.6.3</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Signed-off-by: Ken Chen chenchaokun@gmail.com

# Description

Change the maven dependency version to make demos compatible with Java 11.

## Issue reference

close: #719 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
