### PR TITLE
Fixes broken link in the pub/sub README

### DIFF
--- a/pub_sub/csharp/sdk/README.md
+++ b/pub_sub/csharp/sdk/README.md
@@ -1,6 +1,6 @@
 # Dapr pub/sub
 
-In this quickstart, you'll create a publisher microservice and a subscriber microservice to demonstrate how Dapr enables a publish-subcribe pattern. The publisher will generate messages of a specific topic, while subscribers will listen for messages of specific topics. See [Why Pub-Sub](#why-pub-sub) to understand when this pattern might be a good choice for your software architecture.
+In this quickstart, you'll create a publisher microservice and a subscriber microservice to demonstrate how Dapr enables a publish-subcribe pattern. The publisher will generate messages of a specific topic, while subscribers will listen for messages of specific topics. See [Why Pub-Sub](https://docs.dapr.io/developing-applications/building-blocks/pubsub/pubsub-overview/) to understand when this pattern might be a good choice for your software architecture.
 
 Visit [this](https://docs.dapr.io/developing-applications/building-blocks/pubsub/) link for more information about Dapr and Pub-Sub.
 


### PR DESCRIPTION
Fixes https://github.com/dapr/quickstarts/issues/711

Signed-off-by: Yash Nisar <yashnisar@microsoft.com>

# Description

Fixes a broken link in the README

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: [#[711]](https://github.com/dapr/quickstarts/issues/711)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
