### PR TITLE
Pinning dapr version and fixes multiple validations

### DIFF
--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,0 +1,5 @@
+      DAPR_CLI_VERSION: 1.10.0-rc.2
+      DAPR_RUNTIME_VERSION: 1.10.0-rc.2
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
+      DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
+      MACOS_PYTHON_VERSION: 3.10

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -31,10 +31,8 @@ jobs:
   deploy:
     name: Validate tutorials on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     env:
-      DAPR_CLI_VERSION: 1.10.0-rc.1
-      DAPR_RUNTIME_VERSION: 1.10.0-rc.2
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v1.10.0-rc.1/install/
       GOVER: 1.17
       KUBERNETES_VERSION: v1.21.1
       KIND_VERSION: v0.12.0
@@ -42,7 +40,23 @@ jobs:
     strategy:
       matrix: 
         os: [ubuntu-latest, macos-latest]
+      fail-fast: false
     steps:
+      - name: Check out code 
+        uses: actions/checkout@v2
+      - name: Load environment variables
+        uses: artursouza/export-env-action@v2
+        with:
+          envFile: './.github/env/global.env'
+          expand: 'true'
+      - name: Pinning Python to ${{ env.MACOS_PYTHON_VERSION }} on MacOS
+        if: matrix.os == 'macos-latest'
+        run: brew install python@${{ env.MACOS_PYTHON_VERSION }} && brew unlink python@${{ env.MACOS_PYTHON_VERSION }} && brew link --overwrite python@${{ env.MACOS_PYTHON_VERSION }}
+      - name: Verify Python version
+        run: python3 --version
+      - name: Upgrade pip and setuptools
+        if: matrix.os == 'macos-latest'
+        run: pip3 install --upgrade pip && python3 -m pip install --upgrade setuptools
       - name: Show .Net version
         run: dotnet --version
       - name: Install Docker - MacOS
@@ -124,8 +138,6 @@ jobs:
           dapr init -k --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --wait || kubectl get pods --all-namespaces
           kubectl get nodes -o wide
           for pod in `dapr status -k | awk '/dapr/ {print $1}'`; do kubectl describe pod -l app=$pod -n dapr-system ; kubectl logs -l app=$pod -n dapr-system; done
-      - name: Check out code 
-        uses: actions/checkout@v2
       - name: Install utilities dependencies
         run: |
           echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV

--- a/.github/workflows/validate_new_quickstarts_bindings.yaml
+++ b/.github/workflows/validate_new_quickstarts_bindings.yaml
@@ -31,6 +31,7 @@ jobs:
   deploy:
     name: Validate quickstarts on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
       GOVER: 1.17
@@ -39,10 +40,26 @@ jobs:
       KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
     strategy:
       matrix: 
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
     steps:
+      - name: Check out code 
+        uses: actions/checkout@v2
+      - name: Load environment variables
+        uses: artursouza/export-env-action@v2
+        with:
+          envFile: './.github/env/global.env'
+          expand: 'true'
+      - name: Pinning Python to ${{ env.MACOS_PYTHON_VERSION }} on MacOS
+        if: matrix.os == 'macos-latest'
+        run: brew install python@${{ env.MACOS_PYTHON_VERSION }} && brew unlink python@${{ env.MACOS_PYTHON_VERSION }} && brew link --overwrite python@${{ env.MACOS_PYTHON_VERSION }}
+      - name: Verify Python version
+        run: python3 --version
+      - name: Upgrade pip and setuptools
+        if: matrix.os == 'macos-latest'
+        run: pip3 install --upgrade pip && python3 -m pip install --upgrade setuptools
       - name: Install docker - MacOS
-        if: matrix.os == 'macos-10.15'
+        if: matrix.os == 'macos-latest'
         uses: docker-practice/actions-setup-docker@v1
         with:
           docker_buildx: false
@@ -61,18 +78,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-      - name: Determine latest Dapr Runtime version including Pre-releases
-        run: |
-          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm search repo dapr/dapr --devel --versions | awk '/dapr\/dapr/ {print $3; exit}' )
-          echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          echo "Found $RUNTIME_VERSION"
-        shell: bash
-      - name: Determine latest Dapr Cli version including Pre-releases
-        run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')
-          echo "DAPR_CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
-          echo "Found $CLI_VERSION"
-        shell: bash
       - name: Set up Dapr CLI - Mac/Linux
         if: matrix.os != 'windows-latest'
         run: wget -q ${{ env.DAPR_INSTALL_URL }}/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VERSION }}
@@ -84,8 +89,6 @@ jobs:
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }}
           dapr --version
-      - name: Check out code 
-        uses: actions/checkout@v2
       - name: Install utilities dependencies
         run: |
           echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV

--- a/.github/workflows/validate_new_quickstarts_configuration.yaml
+++ b/.github/workflows/validate_new_quickstarts_configuration.yaml
@@ -31,6 +31,7 @@ jobs:
   validate:
     name: Validate quickstart for `${{ matrix.quickstart_language }}` with `${{ matrix.quickstart_variant }}` on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     env:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
       GOVER: 1.18
@@ -39,12 +40,29 @@ jobs:
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
         quickstart_language: [go, csharp, javascript, python, java]
         quickstart_variant: [http, sdk]
+      fail-fast: false
     steps:
+      - name: Check out code 
+        uses: actions/checkout@v2
+      - name: Load environment variables
+        uses: artursouza/export-env-action@v2
+        with:
+          envFile: './.github/env/global.env'
+          expand: 'true'
+      - name: Pinning Python to ${{ env.MACOS_PYTHON_VERSION }} on MacOS
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: brew install python@${{ env.MACOS_PYTHON_VERSION }} && brew unlink python@${{ env.MACOS_PYTHON_VERSION }} && brew link --overwrite python@${{ env.MACOS_PYTHON_VERSION }}
+      - name: Verify Python version
+        if: matrix.quickstart_language == 'python'
+        run: python3 --version
+      - name: Upgrade pip and setuptools
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: pip3 install --upgrade pip && python3 -m pip install --upgrade setuptools
       - name: Install docker - MacOS
-        if: matrix.os == 'macos-10.15'
+        if: matrix.os == 'macos-latest'
         uses: docker-practice/actions-setup-docker@v1
         with:
           docker_buildx: false
@@ -63,18 +81,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-      - name: Determine latest Dapr Runtime version including Pre-releases
-        run: |
-          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm search repo dapr/dapr --devel --versions | awk '/dapr\/dapr/ {print $3; exit}' )
-          echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          echo "Found $RUNTIME_VERSION"
-        shell: bash
-      - name: Determine latest Dapr Cli version including Pre-releases
-        run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')
-          echo "DAPR_CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
-          echo "Found $CLI_VERSION"
-        shell: bash
       - name: Set up Dapr CLI - Mac/Linux
         if: matrix.os != 'windows-latest'
         run: wget -q ${{ env.DAPR_INSTALL_URL }}/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VERSION }}
@@ -86,8 +92,6 @@ jobs:
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }}
           dapr --version
-      - name: Check out code
-        uses: actions/checkout@v2
       - name: Install utilities dependencies
         run: |
           echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV

--- a/.github/workflows/validate_new_quickstarts_pubsub.yaml
+++ b/.github/workflows/validate_new_quickstarts_pubsub.yaml
@@ -31,25 +31,49 @@ jobs:
   validate:
     name: Validate quickstart for `${{ matrix.quickstart_language }}` with `${{ matrix.quickstart_variant }}` on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     env:
       DAPR_DEFAULT_IMAGE_REGISTRY: GHCR
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
       GOVER: 1.17
       KUBERNETES_VERSION: v1.21.1
       KIND_VERSION: v0.11.0
       KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
     strategy:
       matrix: 
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
         quickstart_language: [go, csharp, javascript, python, java]
         quickstart_variant: [http, sdk]
+      fail-fast: false
     steps:
-      - name: Install docker - MacOS
-        if: matrix.os == 'macos-10.15'
-        uses: docker-practice/actions-setup-docker@v1
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Load environment variables
+        uses: artursouza/export-env-action@v2
         with:
-          docker_buildx: false
-          docker_version: 20.10
+          envFile: './.github/env/global.env'
+          expand: 'true'
+      - name: Pinning Python to ${{ env.MACOS_PYTHON_VERSION }} on MacOS
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: brew install python@${{ env.MACOS_PYTHON_VERSION }} && brew unlink python@${{ env.MACOS_PYTHON_VERSION }} && brew link --overwrite python@${{ env.MACOS_PYTHON_VERSION }}
+      - name: Verify Python version
+        if: matrix.quickstart_language == 'python'
+        run: python3 --version
+      - name: Upgrade pip and setuptools
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: pip3 install --upgrade pip && python3 -m pip install --upgrade setuptools
+      - name: Install podman - MacOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo rm -rf `brew --cache`
+          brew upgrade
+          brew install podman
+          which podman-mac-helper
+          podman_helper=$(which podman-mac-helper)
+          sudo ${podman_helper} install
+          podman machine init
+          podman machine start || echo "VM might not have started"
+          sleep 10
+          podman machine inspect
       - name: Set up Go ${{ env.GOVER }}
         uses: actions/setup-go@v2
         with:
@@ -64,18 +88,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-      - name: Determine latest Dapr Runtime version including Pre-releases
-        run: |
-          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm search repo dapr/dapr --devel --versions | awk '/dapr\/dapr/ {print $3; exit}' )
-          echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          echo "Found $RUNTIME_VERSION"
-        shell: bash
-      - name: Determine latest Dapr Cli version including Pre-releases
-        run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')
-          echo "DAPR_CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
-          echo "Found $CLI_VERSION"
-        shell: bash
       - name: Set up Dapr CLI - Mac/Linux
         if: matrix.os != 'windows-latest'
         run: wget -q ${{ env.DAPR_INSTALL_URL }}/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VERSION }}
@@ -85,10 +97,8 @@ jobs:
       - name: Install Dapr
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }}
+          dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --container-runtime=podman
           dapr --version
-      - name: Check out code 
-        uses: actions/checkout@v2
       - name: Install utilities dependencies
         run: |
           echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV

--- a/.github/workflows/validate_new_quickstarts_secrets_management.yaml
+++ b/.github/workflows/validate_new_quickstarts_secrets_management.yaml
@@ -31,24 +31,48 @@ jobs:
   validate:
     name: Validate quickstart for `${{ matrix.quickstart_language }}` with `${{ matrix.quickstart_variant }}` on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     env:
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
       GOVER: 1.17
       KUBERNETES_VERSION: v1.21.1
       KIND_VERSION: v0.11.0
       KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
     strategy:
       matrix: 
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
         quickstart_language: [go, csharp, javascript, python, java]
         quickstart_variant: [http, sdk]
+      fail-fast: false
     steps:
-      - name: Install docker - MacOS
-        if: matrix.os == 'macos-10.15'
-        uses: docker-practice/actions-setup-docker@v1
+      - name: Check out code 
+        uses: actions/checkout@v2
+      - name: Load environment variables
+        uses: artursouza/export-env-action@v2
         with:
-          docker_buildx: false
-          docker_version: 20.10
+          envFile: './.github/env/global.env'
+          expand: 'true'
+      - name: Pinning Python to ${{ env.MACOS_PYTHON_VERSION }} on MacOS
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: brew install python@${{ env.MACOS_PYTHON_VERSION }} && brew unlink python@${{ env.MACOS_PYTHON_VERSION }} && brew link --overwrite python@${{ env.MACOS_PYTHON_VERSION }}
+      - name: Verify Python version
+        if: matrix.quickstart_language == 'python'
+        run: python3 --version
+      - name: Upgrade pip and setuptools
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: pip3 install --upgrade pip && python3 -m pip install --upgrade setuptools
+      - name: Install podman - MacOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo rm -rf `brew --cache`
+          brew upgrade
+          brew install podman
+          which podman-mac-helper
+          podman_helper=$(which podman-mac-helper)
+          sudo ${podman_helper} install
+          podman machine init
+          podman machine start || echo "VM might not have started"
+          sleep 10
+          podman machine inspect
       - name: Set up Go ${{ env.GOVER }}
         uses: actions/setup-go@v2
         with:
@@ -63,18 +87,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-      - name: Determine latest Dapr Runtime version including Pre-releases
-        run: |
-          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm search repo dapr/dapr --devel --versions | awk '/dapr\/dapr/ {print $3; exit}' )
-          echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          echo "Found $RUNTIME_VERSION"
-        shell: bash
-      - name: Determine latest Dapr Cli version including Pre-releases
-        run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')
-          echo "DAPR_CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
-          echo "Found $CLI_VERSION"
-        shell: bash
       - name: Set up Dapr CLI - Mac/Linux
         if: matrix.os != 'windows-latest'
         run: wget -q ${{ env.DAPR_INSTALL_URL }}/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VERSION }}
@@ -84,10 +96,8 @@ jobs:
       - name: Install Dapr
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }}
+          dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --container-runtime=podman
           dapr --version
-      - name: Check out code 
-        uses: actions/checkout@v2
       - name: Install utilities dependencies
         run: |
           echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV

--- a/.github/workflows/validate_new_quickstarts_service_invo.yaml
+++ b/.github/workflows/validate_new_quickstarts_service_invo.yaml
@@ -31,24 +31,35 @@ jobs:
   validate:
     name: Validate quickstart for `${{ matrix.quickstart_language }}` with `${{ matrix.quickstart_variant }}` on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     env:
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
       GOVER: 1.17
       KUBERNETES_VERSION: v1.21.1
       KIND_VERSION: v0.11.0
       KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
     strategy:
       matrix: 
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
         quickstart_language: [go, csharp, javascript, python, java]
         quickstart_variant: [http]
+      fail-fast: false
     steps:
-      - name: Install docker - MacOS
-        if: matrix.os == 'macos-10.15'
-        uses: docker-practice/actions-setup-docker@v1
+      - name: Check out code 
+        uses: actions/checkout@v2
+      - name: Load environment variables
+        uses: artursouza/export-env-action@v2
         with:
-          docker_buildx: false
-          docker_version: 20.10
+          envFile: './.github/env/global.env'
+          expand: 'true'
+      - name: Pinning Python to ${{ env.MACOS_PYTHON_VERSION }} on MacOS
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: brew install python@${{ env.MACOS_PYTHON_VERSION }} && brew unlink python@${{ env.MACOS_PYTHON_VERSION }} && brew link --overwrite python@${{ env.MACOS_PYTHON_VERSION }}
+      - name: Verify Python version
+        if: matrix.quickstart_language == 'python'
+        run: python3 --version
+      - name: Upgrade pip and setuptools
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: pip3 install --upgrade pip && python3 -m pip install --upgrade setuptools
       - name: Set up Go ${{ env.GOVER }}
         uses: actions/setup-go@v2
         with:
@@ -63,18 +74,6 @@ jobs:
         with:
           dotnet-version: |
             7.0.x
-      - name: Determine latest Dapr Runtime version including Pre-releases
-        run: |
-          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm search repo dapr/dapr --devel --versions | awk '/dapr\/dapr/ {print $3; exit}' )
-          echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          echo "Found $RUNTIME_VERSION"
-        shell: bash
-      - name: Determine latest Dapr Cli version including Pre-releases
-        run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')
-          echo "DAPR_CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
-          echo "Found $CLI_VERSION"
-        shell: bash
       - name: Set up Dapr CLI - Mac/Linux
         if: matrix.os != 'windows-latest'
         run: wget -q ${{ env.DAPR_INSTALL_URL }}/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VERSION }}
@@ -84,10 +83,8 @@ jobs:
       - name: Install Dapr
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }}
+          dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --slim
           dapr --version
-      - name: Check out code 
-        uses: actions/checkout@v2
       - name: Install utilities dependencies
         run: |
           echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV

--- a/.github/workflows/validate_new_quickstarts_state_management.yaml
+++ b/.github/workflows/validate_new_quickstarts_state_management.yaml
@@ -31,24 +31,48 @@ jobs:
   validate:
     name: Validate quickstart for `${{ matrix.quickstart_language }}` with `${{ matrix.quickstart_variant }}` on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     env:
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
       GOVER: 1.17
       KUBERNETES_VERSION: v1.21.1
       KIND_VERSION: v0.11.0
       KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
     strategy:
       matrix: 
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
         quickstart_language: [go, csharp, javascript, python, java]
         quickstart_variant: [http, sdk]
+      fail-fast: false
     steps:
-      - name: Install docker - MacOS
-        if: matrix.os == 'macos-10.15'
-        uses: docker-practice/actions-setup-docker@v1
+      - name: Check out code 
+        uses: actions/checkout@v2
+      - name: Load environment variables
+        uses: artursouza/export-env-action@v2
         with:
-          docker_buildx: false
-          docker_version: 20.10
+          envFile: './.github/env/global.env'
+          expand: 'true'
+      - name: Pinning Python to ${{ env.MACOS_PYTHON_VERSION }} on MacOS
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: brew install python@${{ env.MACOS_PYTHON_VERSION }} && brew unlink python@${{ env.MACOS_PYTHON_VERSION }} && brew link --overwrite python@${{ env.MACOS_PYTHON_VERSION }}
+      - name: Verify Python version
+        if: matrix.quickstart_language == 'python'
+        run: python3 --version
+      - name: Upgrade pip and setuptools
+        if: matrix.os == 'macos-latest' && matrix.quickstart_language == 'python'
+        run: pip3 install --upgrade pip && python3 -m pip install --upgrade setuptools
+      - name: Install podman - MacOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo rm -rf `brew --cache`
+          brew upgrade
+          brew install podman
+          which podman-mac-helper
+          podman_helper=$(which podman-mac-helper)
+          sudo ${podman_helper} install
+          podman machine init
+          podman machine start || echo "VM might not have started"
+          sleep 10
+          podman machine inspect
       - name: Set up Go ${{ env.GOVER }}
         uses: actions/setup-go@v2
         with:
@@ -63,18 +87,6 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-      - name: Determine latest Dapr Runtime version including Pre-releases
-        run: |
-          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm search repo dapr/dapr --devel --versions | awk '/dapr\/dapr/ {print $3; exit}' )
-          echo "DAPR_RUNTIME_VERSION=$RUNTIME_VERSION" >> $GITHUB_ENV
-          echo "Found $RUNTIME_VERSION"
-        shell: bash
-      - name: Determine latest Dapr Cli version including Pre-releases
-        run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')
-          echo "DAPR_CLI_VERSION=$CLI_VERSION" >> $GITHUB_ENV
-          echo "Found $CLI_VERSION"
-        shell: bash
       - name: Set up Dapr CLI - Mac/Linux
         if: matrix.os != 'windows-latest'
         run: wget -q ${{ env.DAPR_INSTALL_URL }}/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VERSION }}
@@ -84,10 +96,8 @@ jobs:
       - name: Install Dapr
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }}
+          dapr init --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --container-runtime podman
           dapr --version
-      - name: Check out code 
-        uses: actions/checkout@v2
       - name: Install utilities dependencies
         run: |
           echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV

--- a/configuration/csharp/sdk/order-processor/Program.cs
+++ b/configuration/csharp/sdk/order-processor/Program.cs
@@ -17,10 +17,10 @@ foreach (var item in config.Items)
   Console.WriteLine("Configuration for " + item.Key + ": " + cfg);
 }
 
-// Exit the app after 20 seconds
+// Exit the app after 30 seconds
 var shutdownTimer = new System.Timers.Timer();
-shutdownTimer.Interval = 20000;
-shutdownTimer.Elapsed += (o, e) => unsubscribe(subscriptionId);
+shutdownTimer.Interval = 30000;
+shutdownTimer.Elapsed += (o, e) => Task.Run(async () => await unsubscribe(subscriptionId)).GetAwaiter().GetResult();
 shutdownTimer.Start();
 
 // Subscribe for configuration changes
@@ -42,11 +42,11 @@ await foreach (var configItem in subscribe.Source)
 
 
 // Unsubscribe to config updates and exit the app
-void unsubscribe(string subscriptionId)
+async Task unsubscribe(string subscriptionId)
 {
   try
   {
-    client.UnsubscribeConfiguration(DAPR_CONFIGURATION_STORE, subscriptionId);
+    await client.UnsubscribeConfiguration(DAPR_CONFIGURATION_STORE, subscriptionId);
     Console.WriteLine("App unsubscribed from config changes");
     Environment.Exit(0);
   }

--- a/pub_sub/go/http/README.md
+++ b/pub_sub/go/http/README.md
@@ -39,8 +39,8 @@ dapr run --app-port 6001 --app-id order-processor --app-protocol http --dapr-htt
 <!-- STEP
 name: Run Go publisher
 expected_stdout_lines:
-  - '== APP == Published data:  {"orderId":1}'
-  - '== APP == Published data:  {"orderId":2}'
+  - '== APP == Published data: {"orderId":1}'
+  - '== APP == Published data: {"orderId":2}'
   - "Exited App successfully"
 expected_stderr_lines:
 output_match_mode: substring

--- a/service_invocation/csharp/http/README.md
+++ b/service_invocation/csharp/http/README.md
@@ -127,7 +127,6 @@ sleep: 15
 -->
 
 ```bash
-sleep 10
 dapr run -f .
 ```
 

--- a/service_invocation/go/http/README.md
+++ b/service_invocation/go/http/README.md
@@ -89,7 +89,6 @@ sleep: 15
 -->
 
 ```bash
-sleep 10
 dapr run -f .
 ```
 

--- a/service_invocation/java/http/README.md
+++ b/service_invocation/java/http/README.md
@@ -130,7 +130,6 @@ sleep: 15
 -->
 
 ```bash
-sleep 10
 dapr run -f .
 ```
 

--- a/service_invocation/java/http/dapr.yaml
+++ b/service_invocation/java/http/dapr.yaml
@@ -1,6 +1,4 @@
 version: 1
-common:
-  configFilePath: ./config.yaml
 apps:
   - appDirPath: ./order-processor/
     appID: order-processor

--- a/service_invocation/javascript/http/README.md
+++ b/service_invocation/javascript/http/README.md
@@ -124,7 +124,6 @@ sleep: 15
 -->
 
 ```bash
-sleep 10
 dapr run -f .
 ```
 

--- a/service_invocation/javascript/http/dapr.yaml
+++ b/service_invocation/javascript/http/dapr.yaml
@@ -1,6 +1,4 @@
 version: 1
-common:
-  configFilePath: ./config.yaml
 apps:
   - appDirPath: ./order-processor/
     appID: order-processor

--- a/service_invocation/python/http/README.md
+++ b/service_invocation/python/http/README.md
@@ -14,15 +14,14 @@ And one order processor service:
 
 ### Run Python order-processor with Dapr
 
-1. Open a new terminal window and navigate to `order-processor` directory and install dependencies: 
+1. Install dependencies for `order-processor` app: 
 
 <!-- STEP
 name: Install Python dependencies
 -->
 
 ```bash
-cd ./order-processor
-pip3 install -r requirements.txt 
+pip3 install -r order-processor/requirements.txt 
 ```
 
 <!-- END_STEP -->
@@ -41,23 +40,21 @@ sleep: 15
 -->
 
 ```bash
-cd ./order-processor
-dapr run --app-port 8001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- python3 app.py
+dapr run --app-port 8001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- python3 order-processor/app.py
 ```
 
 <!-- END_STEP -->
 
 ### Run Python checkout with Dapr
 
-1. Open a new terminal window and navigate to `checkout` directory and install dependencies: 
+1. Open a new terminal window and install dependencies for `checkout` app: 
 
 <!-- STEP
 name: Install Python dependencies
 -->
 
 ```bash
-cd ./checkout
-pip3 install -r requirements.txt 
+pip3 install -r checkout/requirements.txt 
 ```
 
 <!-- END_STEP -->
@@ -77,8 +74,7 @@ sleep: 15
 -->
     
 ```bash
-cd ./checkout
-dapr run  --app-id checkout --app-protocol http --dapr-http-port 3500 -- python3 app.py
+dapr run  --app-id checkout --app-protocol http --dapr-http-port 3500 -- python3 checkout/app.py
 ```
 
 <!-- END_STEP -->
@@ -90,22 +86,7 @@ dapr stop --app-id order-processor
 
 ### Start all apps with multi app run template file:
 
-1. Open a new terminal window and install dependencies for `order-processor` and `checkout` apps:
-
-<!-- STEP
-name: Install Python dependencies for order-processor and checkout
--->
-
-```bash
-cd ./order-processor
-pip3 install -r requirements.txt
-cd ../checkout
-pip3 install -r requirements.txt
-```
-
-<!-- END_STEP -->
-
-2. Run the multi app run template:
+The dependencies are already installed from previous steps. Simply run the multi app run template. It uses `dapr.yaml` file to determine which applications to run.
 
 <!-- STEP
 name: Run multi app run template
@@ -124,11 +105,12 @@ sleep: 15
 -->
 
 ```bash
-sleep 10
 dapr run -f .
 ```
 
 <!-- END_STEP -->
+
+Finally, stop all:
 
 ```bash
 dapr stop -f .

--- a/service_invocation/python/http/dapr.yaml
+++ b/service_invocation/python/http/dapr.yaml
@@ -1,6 +1,4 @@
 version: 1
-common:
-  configFilePath: ./config.yaml
 apps:
   - appDirPath: ./order-processor/
     appID: order-processor


### PR DESCRIPTION
Signed-off-by: Artur Souza <asouza.pro@gmail.com>

# Description

Pinning dapr version and fixes validations:
+ Fix expected outputs in multiple places
+ Fixed Python runs by pinning to Python 3.10 on MacOS
+ Use Podman on every quickstart that does not refer to Docker CLI commands
+ Limit workflows to 30min or less to avoid taking over worker for hours/days
+ Use GHCR instead of Docker Hub everywhere
+ Pin DAPR runtime and CLI because automation was picking the latest, so a hotfix after an RC did mess up with the validation for 1.10 release
+ Removed unnecessary sleep in `dapr run -f` scenario
+ Fixed reference to removed confing.yaml since Resiliency is on by default now.


## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: endgame
Closes: https://github.com/dapr/quickstarts/issues/762

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
