### PR TITLE
adjust service_invocation/csharp order-processor port

### DIFF
--- a/pub_sub/csharp/sdk/README.md
+++ b/pub_sub/csharp/sdk/README.md
@@ -46,7 +46,7 @@ sleep: 10
 
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ --app-port 7005 -- dotnet run --project .
+dapr run --app-id order-processor --resources-path ../../../components/ --app-port 7002 -- dotnet run --project .
 ```
 
 <!-- END_STEP -->

--- a/pub_sub/csharp/sdk/order-processor/Properties/launchSettings.json
+++ b/pub_sub/csharp/sdk/order-processor/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:7005",
+      "applicationUrl": "http://localhost:7002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/service_invocation/csharp/http/README.md
+++ b/service_invocation/csharp/http/README.md
@@ -43,7 +43,7 @@ sleep: 10
 
 ```bash
 cd ./order-processor
-dapr run --app-port 7006 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- dotnet run
+dapr run --app-port 7001 --app-id order-processor --app-protocol http --dapr-http-port 3501 -- dotnet run
 ```
 
 <!-- END_STEP -->

--- a/service_invocation/csharp/http/dapr.yaml
+++ b/service_invocation/csharp/http/dapr.yaml
@@ -2,7 +2,7 @@ version: 1
 apps:
   - appDirPath: ./order-processor/
     appID: order-processor
-    appPort: 7006
+    appPort: 7001
     command: ["dotnet", "run"]
   - appID: checkout
     appDirPath: ./checkout/

--- a/service_invocation/csharp/http/order-processor/Properties/launchSettings.json
+++ b/service_invocation/csharp/http/order-processor/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:7006",
+      "applicationUrl": "http://localhost:7001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
# Description

In the C# service invocation quickstart order-processor service, changed the port from `7006` to `7001` to align with the [quickstart instructions](https://docs.dapr.io/getting-started/quickstarts/serviceinvocation-quickstart/#step-3-run-order-processor-service).

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

PR is in response to issue: https://github.com/dapr/docs/issues/3296

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
