### PR TITLE
[Workflow] Updates for v1.11

### DIFF
--- a/workflows/csharp/sdk/order-processor/Program.cs
+++ b/workflows/csharp/sdk/order-processor/Program.cs
@@ -7,7 +7,8 @@ using WorkflowConsoleApp.Activities;
 using WorkflowConsoleApp.Models;
 using WorkflowConsoleApp.Workflows;
 
-const string storeName = "statestore";
+const string StoreName = "statestore";
+const string DaprWorkflowComponent = "dapr";
 
 // The workflow host is a background service that connects to the sidecar over gRPC
 var builder = Host.CreateDefaultBuilder(args).ConfigureServices(services =>
@@ -68,6 +69,6 @@ Console.WriteLine("Workflow Status: {0}", state.RuntimeStatus);
 
 void RestockInventory()
 {
-    daprClient.SaveStateAsync<OrderPayload>(storeName, "Cars",  new OrderPayload(Name: "Cars", TotalCost: 15000, Quantity: 100));
+    daprClient.SaveStateAsync<OrderPayload>(StoreName, "Cars",  new OrderPayload(Name: "Cars", TotalCost: 15000, Quantity: 100));
     return;
 }

--- a/workflows/csharp/sdk/order-processor/Program.cs
+++ b/workflows/csharp/sdk/order-processor/Program.cs
@@ -69,6 +69,6 @@ Console.WriteLine("Workflow Status: {0}", state.RuntimeStatus);
 
 void RestockInventory()
 {
-    daprClient.SaveStateAsync<OrderPayload>(StoreName, "Cars",  new OrderPayload(Name: "Cars", TotalCost: 15000, Quantity: 100));
+    daprClient.SaveStateAsync<OrderPayload>(StoreName, itemToPurchase,  new OrderPayload(Name: itemToPurchase, TotalCost: 15000, Quantity: 100));
     return;
 }

--- a/workflows/csharp/sdk/order-processor/WorkflowConsoleApp.csproj
+++ b/workflows/csharp/sdk/order-processor/WorkflowConsoleApp.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.10.0-rc02" />
-    <PackageReference Include="Dapr.Workflow" Version="1.10.0-rc02" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.11.*" />
+    <PackageReference Include="Dapr.Workflow" Version="1.11.*" />
   </ItemGroup>
 
 </Project>

--- a/workflows/csharp/sdk/order-processor/WorkflowConsoleApp.csproj
+++ b/workflows/csharp/sdk/order-processor/WorkflowConsoleApp.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.11.*" />
-    <PackageReference Include="Dapr.Workflow" Version="1.11.*" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.11.*-*" />
+    <PackageReference Include="Dapr.Workflow" Version="1.11.*-*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Description

This PR contains updates for the workflow quickstart to make it compatible with v1.11, which has many breaking changes since v1.10. Some quick notes about the changes that impact this existing quickstart:

- We've removed the need for the `DaprWorkflowClient` class. Instead, we can just use `DaprClient` as originally intended.
- Looping and sleeping have been replaced with first-class "WaitForWorkflowXXX" methods on the DaprClient.

This PR depends on a v1.11 .NET SDK to be available on nuget.org. It won't run without this.

Resolves https://github.com/dapr/quickstarts/issues/830.

cc @msfussell @hhunter-ms @nyemade-uversky @RyanLettieri @halspang 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
