### PR TITLE
Unique ports to fix C# tests collisions

### DIFF
--- a/bindings/csharp/http/README.md
+++ b/bindings/csharp/http/README.md
@@ -61,7 +61,7 @@ timeout_seconds: 30
 -->
     
 ```bash
-dapr run --app-id batch-http --app-port 7001 --resources-path ../../../components -- dotnet run
+dapr run --app-id batch-http --app-port 7003 --resources-path ../../../components -- dotnet run
 ```
 
 <!-- END_STEP -->

--- a/bindings/csharp/http/batch/Properties/launchSettings.json
+++ b/bindings/csharp/http/batch/Properties/launchSettings.json
@@ -6,7 +6,7 @@
         "dotnetRunMessages": "true",
         "launchBrowser": true,
         "launchUrl": "swagger",
-        "applicationUrl": "http://localhost:7001",
+        "applicationUrl": "http://localhost:7003",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }

--- a/configuration/csharp/http/README.md
+++ b/configuration/csharp/http/README.md
@@ -49,7 +49,7 @@ match_order: none
 
 ```bash
 cd ./order-processor
-dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7003 -- dotnet run --project .
+dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7006 -- dotnet run --project .
 ```
 
 <!-- END_STEP -->

--- a/configuration/csharp/http/order-processor/Properties/launchSettings.json
+++ b/configuration/csharp/http/order-processor/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:7003",
+      "applicationUrl": "http://localhost:7006",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/configuration/csharp/sdk/README.md
+++ b/configuration/csharp/sdk/README.md
@@ -47,7 +47,7 @@ match_order: none
 
 ```bash
 cd ./order-processor
-dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7001 -- dotnet run --project .
+dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7007 -- dotnet run --project .
 ```
 
 <!-- END_STEP -->

--- a/pub_sub/csharp/http/README.md
+++ b/pub_sub/csharp/http/README.md
@@ -46,7 +46,7 @@ sleep: 10
 
 
 ```bash
-dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7004 -- dotnet run --project .
+dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7005 -- dotnet run --project .
 ```
 
 <!-- END_STEP -->

--- a/pub_sub/csharp/http/order-processor/Properties/launchSettings.json
+++ b/pub_sub/csharp/http/order-processor/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:7004",
+      "applicationUrl": "http://localhost:7005",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/pub_sub/csharp/sdk/README.md
+++ b/pub_sub/csharp/sdk/README.md
@@ -46,7 +46,7 @@ sleep: 10
 
 
 ```bash
-dapr run --app-id order-processor --resources-path ../../../components/ --app-port 7002 -- dotnet run --project .
+dapr run --app-id order-processor --resources-path ../../../components/ --app-port 7006 -- dotnet run --project .
 ```
 
 <!-- END_STEP -->

--- a/pub_sub/csharp/sdk/order-processor/Properties/launchSettings.json
+++ b/pub_sub/csharp/sdk/order-processor/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:7002",
+      "applicationUrl": "http://localhost:7006",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
C# projects often overlapped on ports 7001 and 7002 causing collisions during automated testing.


## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
