### PR TITLE
Fixing tutorials workflow

### DIFF
--- a/tutorials/bindings/README.md
+++ b/tutorials/bindings/README.md
@@ -325,7 +325,7 @@ output_match_mode: substring
 expected_stdout_lines:
   - "{'data': {'orderId': " 
   - "{'data': {'orderId': "
-  - "Response for order \d+: 204"
+  - "Response for order \\d+: 204"
 -->
 
 ```bash

--- a/tutorials/bindings/README.md
+++ b/tutorials/bindings/README.md
@@ -325,7 +325,7 @@ output_match_mode: substring
 expected_stdout_lines:
   - "{'data': {'orderId': " 
   - "{'data': {'orderId': "
-  - "Response for order \\d+: 204"
+  - "Response for order 3: 204"
 -->
 
 ```bash

--- a/tutorials/bindings/README.md
+++ b/tutorials/bindings/README.md
@@ -325,7 +325,7 @@ output_match_mode: substring
 expected_stdout_lines:
   - "{'data': {'orderId': " 
   - "{'data': {'orderId': "
-  - "<Response [204]>"
+  - "Response for order \d+: 204"
 -->
 
 ```bash
@@ -337,9 +337,9 @@ kubectl logs --selector app=bindingspythonapp -c python --tail=-1
 ```bash
 ...
 {'data': {'orderId': 10}, 'operation': 'create'}
-<Response [204]>
+Response for order 10: 204
 {'data': {'orderId': 11}, 'operation': 'create'}
-<Response [204]>
+Response for order 11: 204
 ...
 ```
 


### PR DESCRIPTION
# Description

Github actions have been failing for tutorials due to change in logging. This has been fixed by changing the expected logs in markdown file.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #858

