### PR TITLE
Pinning podman to 4.4.4 version

### DIFF
--- a/.github/workflows/validate_csharp_quicstarts.yaml
+++ b/.github/workflows/validate_csharp_quicstarts.yaml
@@ -39,6 +39,7 @@ jobs:
       KUBERNETES_VERSION: v1.25.3
       KIND_VERSION: v0.17.0
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+      PODMAN_VERSION: 4.4.4
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -55,16 +56,16 @@ jobs:
         timeout-minutes: 15
         if: matrix.os == 'macos-latest'
         run: |
-          sudo rm -rf `brew --cache`
-          brew upgrade
-          brew install podman
-          which podman-mac-helper
-          podman_helper=$(which podman-mac-helper)
-          sudo ${podman_helper} install
+          # Install podman
+          curl -sL -o podman.pkg https://github.com/containers/podman/releases/download/v${{ env.PODMAN_VERSION }}/podman-installer-macos-amd64.pkg
+          sudo installer -pkg podman.pkg -target /
+          export PATH=/opt/podman/bin:$PATH
+          echo "/opt/podman/bin" >> $GITHUB_PATH
+          # Start podman machine
+          sudo podman-mac-helper install
           podman machine init
-          podman machine start || echo "VM might not have started"
-          sleep 10
-          podman machine inspect
+          podman machine start --log-level debug
+          echo "CONTAINER_RUNTIME=podman" >> $GITHUB_ENV
       - name: Install podman-compose
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/validate_go_quickstarts.yaml
+++ b/.github/workflows/validate_go_quickstarts.yaml
@@ -39,6 +39,7 @@ jobs:
       KUBERNETES_VERSION: v1.21.1
       KIND_VERSION: v0.11.0
       KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+      PODMAN_VERSION: 4.4.4
     strategy:
       matrix: 
         os: [ubuntu-latest, macos-latest]
@@ -55,16 +56,16 @@ jobs:
         timeout-minutes: 15
         if: matrix.os == 'macos-latest'
         run: |
-          sudo rm -rf `brew --cache`
-          brew upgrade
-          brew install podman
-          which podman-mac-helper
-          podman_helper=$(which podman-mac-helper)
-          sudo ${podman_helper} install
+          # Install podman
+          curl -sL -o podman.pkg https://github.com/containers/podman/releases/download/v${{ env.PODMAN_VERSION }}/podman-installer-macos-amd64.pkg
+          sudo installer -pkg podman.pkg -target /
+          export PATH=/opt/podman/bin:$PATH
+          echo "/opt/podman/bin" >> $GITHUB_PATH
+          # Start podman machine
+          sudo podman-mac-helper install
           podman machine init
-          podman machine start || echo "VM might not have started"
-          sleep 10
-          podman machine inspect
+          podman machine start --log-level debug
+          echo "CONTAINER_RUNTIME=podman" >> $GITHUB_ENV
       - name: Install podman-compose
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/validate_java_quicstarts.yaml
+++ b/.github/workflows/validate_java_quicstarts.yaml
@@ -39,6 +39,7 @@ jobs:
       KUBERNETES_VERSION: v1.25.3
       KIND_VERSION: v0.17.0
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+      PODMAN_VERSION: 4.4.4
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -55,16 +56,16 @@ jobs:
         timeout-minutes: 15
         if: matrix.os == 'macos-latest'
         run: |
-          sudo rm -rf `brew --cache`
-          brew upgrade
-          brew install podman
-          which podman-mac-helper
-          podman_helper=$(which podman-mac-helper)
-          sudo ${podman_helper} install
+          # Install podman
+          curl -sL -o podman.pkg https://github.com/containers/podman/releases/download/v${{ env.PODMAN_VERSION }}/podman-installer-macos-amd64.pkg
+          sudo installer -pkg podman.pkg -target /
+          export PATH=/opt/podman/bin:$PATH
+          echo "/opt/podman/bin" >> $GITHUB_PATH
+          # Start podman machine
+          sudo podman-mac-helper install
           podman machine init
-          podman machine start || echo "VM might not have started"
-          sleep 10
-          podman machine inspect
+          podman machine start --log-level debug
+          echo "CONTAINER_RUNTIME=podman" >> $GITHUB_ENV
       - name: Install podman-compose
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/validate_javascript_quicstarts.yaml
+++ b/.github/workflows/validate_javascript_quicstarts.yaml
@@ -39,6 +39,7 @@ jobs:
       KUBERNETES_VERSION: v1.25.3
       KIND_VERSION: v0.17.0
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+      PODMAN_VERSION: 4.4.4
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -55,16 +56,16 @@ jobs:
         timeout-minutes: 15
         if: matrix.os == 'macos-latest'
         run: |
-          sudo rm -rf `brew --cache`
-          brew upgrade
-          brew install podman
-          which podman-mac-helper
-          podman_helper=$(which podman-mac-helper)
-          sudo ${podman_helper} install
+          # Install podman
+          curl -sL -o podman.pkg https://github.com/containers/podman/releases/download/v${{ env.PODMAN_VERSION }}/podman-installer-macos-amd64.pkg
+          sudo installer -pkg podman.pkg -target /
+          export PATH=/opt/podman/bin:$PATH
+          echo "/opt/podman/bin" >> $GITHUB_PATH
+          # Start podman machine
+          sudo podman-mac-helper install
           podman machine init
-          podman machine start || echo "VM might not have started"
-          sleep 10
-          podman machine inspect
+          podman machine start --log-level debug
+          echo "CONTAINER_RUNTIME=podman" >> $GITHUB_ENV
       - name: Install podman-compose
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/validate_python_quicstarts.yaml
+++ b/.github/workflows/validate_python_quicstarts.yaml
@@ -39,6 +39,7 @@ jobs:
       KUBERNETES_VERSION: v1.25.3
       KIND_VERSION: v0.17.0
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+      PODMAN_VERSION: 4.4.4
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -63,16 +64,16 @@ jobs:
         timeout-minutes: 15
         if: matrix.os == 'macos-latest'
         run: |
-          sudo rm -rf `brew --cache`
-          brew upgrade
-          brew install podman
-          which podman-mac-helper
-          podman_helper=$(which podman-mac-helper)
-          sudo ${podman_helper} install
+          # Install podman
+          curl -sL -o podman.pkg https://github.com/containers/podman/releases/download/v${{ env.PODMAN_VERSION }}/podman-installer-macos-amd64.pkg
+          sudo installer -pkg podman.pkg -target /
+          export PATH=/opt/podman/bin:$PATH
+          echo "/opt/podman/bin" >> $GITHUB_PATH
+          # Start podman machine
+          sudo podman-mac-helper install
           podman machine init
-          podman machine start || echo "VM might not have started"
-          sleep 10
-          podman machine inspect
+          podman machine start --log-level debug
+          echo "CONTAINER_RUNTIME=podman" >> $GITHUB_ENV
       - name: Install podman-compose
         if: matrix.os == 'macos-latest'
         run: |


### PR DESCRIPTION
# Description

Latest version of Podman seems to be unstable where it times out more often, so pinning the podman version to 4.4.4, which is more reliable as of now..

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #862
