### PR TITLE
Update configuration api sdks to stable

### DIFF
--- a/configuration/csharp/sdk/order-processor/Program.csproj
+++ b/configuration/csharp/sdk/order-processor/Program.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="Dapr.AspNetCore" Version="1.11.0" />
   </ItemGroup>
 
 </Project>

--- a/configuration/go/sdk/order-processor/go.mod
+++ b/configuration/go/sdk/order-processor/go.mod
@@ -2,7 +2,7 @@ module dapr_example
 
 go 1.19
 
-require github.com/dapr/go-sdk v1.6.1-0.20230529015951-df5bd08997c3
+require github.com/dapr/go-sdk v1.8.0
 
 require (
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/configuration/go/sdk/order-processor/go.sum
+++ b/configuration/go/sdk/order-processor/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapr/go-sdk v1.6.1-0.20230529015951-df5bd08997c3 h1:e0Tn1pqdCApcKtVp4ntPrj2dUnNOP8rcfbOCc88CJWI=
-github.com/dapr/go-sdk v1.6.1-0.20230529015951-df5bd08997c3/go.mod h1:MBcTKXg8PmBc8A968tVWQg1Xt+DZtmeVR6zVVVGcmeA=
+github.com/dapr/go-sdk v1.8.0 h1:OEleeL3zUTqXxIZ7Vkk3PClAeCh1g8sZ1yR2JFZKfXM=
+github.com/dapr/go-sdk v1.8.0/go.mod h1:MBcTKXg8PmBc8A968tVWQg1Xt+DZtmeVR6zVVVGcmeA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=

--- a/configuration/java/sdk/order-processor/pom.xml
+++ b/configuration/java/sdk/order-processor/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.9.0-rc-1</version>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/configuration/javascript/sdk/order-processor/package-lock.json
+++ b/configuration/javascript/sdk/order-processor/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@dapr/dapr": "^3.0.0"
+                "@dapr/dapr": "^3.1.0"
             },
             "devDependencies": {
                 "eslint": "^8.8.0",
@@ -17,9 +17,9 @@
             }
         },
         "node_modules/@dapr/dapr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.0.0.tgz",
-            "integrity": "sha512-6KwrEPFAQUD1mo5A9c3q/DJ/Xr/e8fL/3Ig6Sjt0c+NHhbEt8W43fqQKjlhG1p3UqHos2QNMMFXM69U5xs4lBA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.0.tgz",
+            "integrity": "sha512-k3jGmbm5FIf2s5zzQYq9zeGX/mbrO4PQeRckkhB4uRiqExBmosWtFoDzwFK346c7eaO2my4lodobYYY6yUImyw==",
             "dependencies": {
                 "@grpc/grpc-js": "^1.3.7",
                 "@js-temporal/polyfill": "^0.3.0",
@@ -2970,9 +2970,9 @@
     },
     "dependencies": {
         "@dapr/dapr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.0.0.tgz",
-            "integrity": "sha512-6KwrEPFAQUD1mo5A9c3q/DJ/Xr/e8fL/3Ig6Sjt0c+NHhbEt8W43fqQKjlhG1p3UqHos2QNMMFXM69U5xs4lBA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.0.tgz",
+            "integrity": "sha512-k3jGmbm5FIf2s5zzQYq9zeGX/mbrO4PQeRckkhB4uRiqExBmosWtFoDzwFK346c7eaO2my4lodobYYY6yUImyw==",
             "requires": {
                 "@grpc/grpc-js": "^1.3.7",
                 "@js-temporal/polyfill": "^0.3.0",

--- a/configuration/python/sdk/order-processor/requirements.txt
+++ b/configuration/python/sdk/order-processor/requirements.txt
@@ -1,2 +1,2 @@
-dapr-dev #This is for RC testing and is unsupported.  Replace with `dapr` for stable releases.
+dapr
 typing-extensions


### PR DESCRIPTION
# Description

This PR updates the Dapr SDKs being used in Configuration API Quickstart to their latest releases. 

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #847 
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
