### PR TITLE
Fixups for JS crypto quickstart

### DIFF
--- a/cryptography/javascript/sdk/README.md
+++ b/cryptography/javascript/sdk/README.md
@@ -60,7 +60,7 @@ expected_stdout_lines:
   - "== APP == Encrypting federico-di-dio-photography-Q4g0Q-eVVEg-unsplash.jpg to encrypted.out"
   - "== APP == Encrypted the message to encrypted.out"
   - "== APP == == Decrypting message using streams"
-  - "== APP == Encrypting encrypted.out to decrypted.out"
+  - "== APP == Decrypting encrypted.out to decrypted.out.jpg"
   - "== APP == Decrypted the message to decrypted.out.jpg"
   - "Exited App successfully"
 expected_stderr_lines:

--- a/cryptography/javascript/sdk/crypto-quickstart/index.mjs
+++ b/cryptography/javascript/sdk/crypto-quickstart/index.mjs
@@ -72,7 +72,7 @@ async function encryptDecryptStream(client) {
 
   // Decrypt the message
   console.log("== Decrypting message using streams");
-  console.log("Encrypting encrypted.out to decrypted.out");
+  console.log("Decrypting encrypted.out to decrypted.out.jpg");
   await pipeline(
     createReadStream("encrypted.out"),
     await client.crypto.decrypt({
@@ -84,4 +84,5 @@ async function encryptDecryptStream(client) {
   console.log("Decrypted the message to decrypted.out.jpg");
 }
 
+// Start the code
 await start();

--- a/cryptography/javascript/sdk/crypto-quickstart/package-lock.json
+++ b/cryptography/javascript/sdk/crypto-quickstart/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@dapr/dapr": "3.1.1"
+                "@dapr/dapr": "~3.1.2"
             },
             "devDependencies": {
                 "@types/node": "^18.0.0",
@@ -17,9 +17,9 @@
             }
         },
         "node_modules/@dapr/dapr": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.1.tgz",
-            "integrity": "sha512-Fb5BpQMfN5UbrMCU6nMD8mmKPwvUcyxeN79/DdkCrdxDttpIIlSSGJ5mp3lNVYcMB8Xo2wMJHwMfKJ4QqaQBRQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.2.tgz",
+            "integrity": "sha512-RmGFRiKRA/PsYngBWG53Ibz26i1iaXP7wXAjkvpvlWsS2rRbZKCF3Qw6/MJ3TeWhRLQkR7oXc7iOpvfEHKqDFw==",
             "dependencies": {
                 "@grpc/grpc-js": "^1.3.7",
                 "@js-temporal/polyfill": "^0.3.0",
@@ -2271,9 +2271,9 @@
     },
     "dependencies": {
         "@dapr/dapr": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.1.tgz",
-            "integrity": "sha512-Fb5BpQMfN5UbrMCU6nMD8mmKPwvUcyxeN79/DdkCrdxDttpIIlSSGJ5mp3lNVYcMB8Xo2wMJHwMfKJ4QqaQBRQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.2.tgz",
+            "integrity": "sha512-RmGFRiKRA/PsYngBWG53Ibz26i1iaXP7wXAjkvpvlWsS2rRbZKCF3Qw6/MJ3TeWhRLQkR7oXc7iOpvfEHKqDFw==",
             "requires": {
                 "@grpc/grpc-js": "^1.3.7",
                 "@js-temporal/polyfill": "^0.3.0",

--- a/cryptography/javascript/sdk/crypto-quickstart/package-lock.json
+++ b/cryptography/javascript/sdk/crypto-quickstart/package-lock.json
@@ -9,16 +9,17 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@dapr/dapr": "3.1.0"
+                "@dapr/dapr": "3.1.1"
             },
             "devDependencies": {
+                "@types/node": "^18.0.0",
                 "eslint": "^8.42.0"
             }
         },
         "node_modules/@dapr/dapr": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.0.tgz",
-            "integrity": "sha512-k3jGmbm5FIf2s5zzQYq9zeGX/mbrO4PQeRckkhB4uRiqExBmosWtFoDzwFK346c7eaO2my4lodobYYY6yUImyw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.1.tgz",
+            "integrity": "sha512-Fb5BpQMfN5UbrMCU6nMD8mmKPwvUcyxeN79/DdkCrdxDttpIIlSSGJ5mp3lNVYcMB8Xo2wMJHwMfKJ4QqaQBRQ==",
             "dependencies": {
                 "@grpc/grpc-js": "^1.3.7",
                 "@js-temporal/polyfill": "^0.3.0",
@@ -2270,9 +2271,9 @@
     },
     "dependencies": {
         "@dapr/dapr": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.0.tgz",
-            "integrity": "sha512-k3jGmbm5FIf2s5zzQYq9zeGX/mbrO4PQeRckkhB4uRiqExBmosWtFoDzwFK346c7eaO2my4lodobYYY6yUImyw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.1.1.tgz",
+            "integrity": "sha512-Fb5BpQMfN5UbrMCU6nMD8mmKPwvUcyxeN79/DdkCrdxDttpIIlSSGJ5mp3lNVYcMB8Xo2wMJHwMfKJ4QqaQBRQ==",
             "requires": {
                 "@grpc/grpc-js": "^1.3.7",
                 "@js-temporal/polyfill": "^0.3.0",

--- a/cryptography/javascript/sdk/crypto-quickstart/package.json
+++ b/cryptography/javascript/sdk/crypto-quickstart/package.json
@@ -12,9 +12,10 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "@dapr/dapr": "3.1.0"
+        "@dapr/dapr": "3.1.1"
     },
     "devDependencies": {
+        "@types/node": "^18.0.0",
         "eslint": "^8.42.0"
     }
 }

--- a/cryptography/javascript/sdk/crypto-quickstart/package.json
+++ b/cryptography/javascript/sdk/crypto-quickstart/package.json
@@ -12,7 +12,7 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "@dapr/dapr": "3.1.1"
+        "@dapr/dapr": "~3.1.2"
     },
     "devDependencies": {
         "@types/node": "^18.0.0",


### PR DESCRIPTION
2 fixes for JS crypto quickstart:

1. Updated the JS SDK to 3.1.1 to fix an issue that was detected in the tests in this repo (https://github.com/dapr/js-sdk/pull/503)
1. Fixed 2 typos in output