### PR TITLE
Tutorials test fix - broken link

### DIFF
--- a/tutorials/distributed-calculator/README.md
+++ b/tutorials/distributed-calculator/README.md
@@ -8,7 +8,7 @@ This quickstart shows method invocation and state persistent capabilities of Dap
 - **Subtraction**: [.NET Core](https://docs.microsoft.com/en-us/dotnet/core/) application
 
 The front-end application consists of a server and a client written in [React](https://reactjs.org/). 
-Kudos to [ahfarmer](https://github.com/ahfarmer) whose [React calculator](https://github.com/ahfarmer/calculator) 
+Kudos to `ahfarmer` whose [React calculator](https://github.com/ahfarmer/calculator) 
 
 The following architecture diagram illustrates the components that make up this quickstart: 
 


### PR DESCRIPTION
# Description

Removing broken link to user profile, and keeping link to archived repo

## Issue reference

Fixes this recurring test failure:
https://github.com/dapr/quickstarts/actions/runs/5256605105/jobs/9498167540#step:22:872
