### PR TITLE
fix(go-http): http quickstart is broken 

### DIFF
--- a/pub_sub/go/http/order-processor/app.go
+++ b/pub_sub/go/http/order-processor/app.go
@@ -18,7 +18,7 @@ type JSONObj struct {
 }
 
 type Result struct {
-	Data string `json:"data"`
+	Data map[string]int `json:"data"`
 }
 
 func getOrder(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +49,10 @@ func postOrder(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	fmt.Println("Subscriber received:", string(result.Data))
+	for k, v := range result.Data {
+		d := fmt.Sprintf(`Subscriber received: {"%s":%d}`, k, v)
+		fmt.Println(d)
+	}
 	obj, err := json.Marshal(data)
 	if err != nil {
 		log.Fatal(err.Error())


### PR DESCRIPTION
# Description

The Go HTTP quickstart for pubsub is currently broken. It tries to unmarshal the data the publisher sends into a string. It is not a string, but rather a json string of a map[string]int. I checked with other languages such as python and it seems they also expect a map so went with that. Tested and fix my issue.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
