### PR TITLE
pub_sub: go: set publisher sleep to 1 second

### DIFF
--- a/pub_sub/go/http/checkout/app.go
+++ b/pub_sub/go/http/checkout/app.go
@@ -45,6 +45,6 @@ func main() {
 
 		fmt.Println("Published data:", order)
 
-		time.Sleep(1000)
+		time.Sleep(time.Second)
 	}
 }

--- a/pub_sub/go/sdk/checkout/app.go
+++ b/pub_sub/go/sdk/checkout/app.go
@@ -33,6 +33,6 @@ func main() {
 
 		fmt.Println("Published data:", order)
 
-		time.Sleep(1000)
+		time.Sleep(time.Second)
 	}
 }


### PR DESCRIPTION
# Description

The current implementation calls `time.Sleep(1000)` with untyped literal `1000`, which is interpreted as 1000 nanoseconds, or 1 millisecond.

This commit changes the sleep duration to proper typed constant `time.Second`, which corresponds to the sleep time of other language examples.

## Issue reference

This issue will close #890.

## Checklist

I have completed all the tasks:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
