### PR TITLE
Fix mismatch port with description

### DIFF
--- a/service_invocation/go/http/order-processor/app.go
+++ b/service_invocation/go/http/order-processor/app.go
@@ -28,7 +28,7 @@ func main() {
 
 	// Start the server listening on port 6001
 	// This is a blocking call
-	err := http.ListenAndServe(":6006", r)
+	err := http.ListenAndServe(":6001", r)
 	if err != http.ErrServerClosed {
 		log.Println("Error starting HTTP server")
 	}


### PR DESCRIPTION
# Description

Port that set in http listener is not the same as description.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
