### PR TITLE
Go build not needed for `go run`

### DIFF
--- a/tutorials/distributed-calculator/README.md
+++ b/tutorials/distributed-calculator/README.md
@@ -53,18 +53,6 @@ working_dir: "./go"
 <!-- END_STEP -->
 
 <!-- STEP
-name: "Build go app"
-working_dir: "./go"
--->
-
-- Build the app. Run:
-   ```bash
-   go build .
-   ```
-
-<!-- END_STEP -->
-
-<!-- STEP
 expected_stdout_lines:
 - "You're up and running! Both Dapr and your app logs will appear here."
 - "== APP == Adding 52.000000 to 34.000000"


### PR DESCRIPTION

# Description
As we use the `go run app.go` command, we do not need to prebuild (i.e `go build .`). 
No code change.

## Issue reference
N/A

## Checklist
* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
