### PR TITLE
update dapr runtime to use v1.12.0-rc.1

### DIFF
--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,5 +1,5 @@
       DAPR_CLI_VERSION: 1.11.0
-      DAPR_RUNTIME_VERSION: 1.11.0
+      DAPR_RUNTIME_VERSION: 1.12.0-rc.1
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
       DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
       MACOS_PYTHON_VERSION: 3.10

--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,5 +1,5 @@
-      DAPR_CLI_VERSION: 1.11.0
-      DAPR_RUNTIME_VERSION: 1.12.0-rc.1
+      DAPR_CLI_VERSION: 1.12.0-rc.1
+      DAPR_RUNTIME_VERSION: 1.12.0-rc.3
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
       DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
       MACOS_PYTHON_VERSION: 3.10

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -134,7 +134,7 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update
-          helm install redis bitnami/redis
+          helm install redis bitnami/redis --version 17.14.5
           dapr init -k --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --wait || kubectl get pods --all-namespaces
           kubectl get nodes -o wide
           for pod in `dapr status -k | awk '/dapr/ {print $1}'`; do kubectl describe pod -l app=$pod -n dapr-system ; kubectl logs -l app=$pod -n dapr-system; done

--- a/configuration/go/sdk/README.md
+++ b/configuration/go/sdk/README.md
@@ -37,7 +37,6 @@ name: Run order-processor service
 expected_stdout_lines:
   - '== APP == Configuration for orderId2: {"Value":"102","Version":"","Metadata":null}'
   - '== APP == App subscribed to config changes with subscription id:'
-  - '== APP == App unsubscribed to config changes'
   - "Exited App successfully"
 expected_stderr_lines:
 output_match_mode: substring

--- a/configuration/go/sdk/order-processor/app.go
+++ b/configuration/go/sdk/order-processor/app.go
@@ -54,5 +54,8 @@ func main() {
 	} else {
 		fmt.Println("App unsubscribed to config changes")
 	}
+
+	time.Sleep(10 * time.Second)
+
 	os.Exit(0)
 }

--- a/configuration/go/sdk/order-processor/app.go
+++ b/configuration/go/sdk/order-processor/app.go
@@ -46,7 +46,7 @@ func main() {
 	}
 	fmt.Println("App subscribed to config changes with subscription id: " + subscriptionID)
 
-	time.Sleep(5 * time.Second)
+<-ctx.Done()
 
 	os.Exit(0)
 }

--- a/configuration/go/sdk/order-processor/app.go
+++ b/configuration/go/sdk/order-processor/app.go
@@ -55,7 +55,5 @@ func main() {
 		fmt.Println("App unsubscribed to config changes")
 	}
 
-	time.Sleep(10 * time.Second)
-
 	os.Exit(0)
 }

--- a/configuration/go/sdk/order-processor/app.go
+++ b/configuration/go/sdk/order-processor/app.go
@@ -46,14 +46,7 @@ func main() {
 	}
 	fmt.Println("App subscribed to config changes with subscription id: " + subscriptionID)
 
-	time.Sleep(10 * time.Second)
-
-	err = client.UnsubscribeConfigurationItems(context.Background(), DAPR_CONFIGURATION_STORE, subscriptionID)
-	if err != nil {
-		fmt.Println("Error unsubscribing to config updates, err:" + err.Error())
-	} else {
-		fmt.Println("App unsubscribed to config changes")
-	}
+	time.Sleep(5 * time.Second)
 
 	os.Exit(0)
 }


### PR DESCRIPTION
# Description

Update dapr runtime to use v1.12.0-rc.3 && dapr cli to use v1.12.0-rc.1 to test & validate the release candidate

## Issue reference

https://github.com/dapr/dapr/issues/6899

## Checklist

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
