### PR TITLE
Add holopin.yml config for GHC2023 event

### DIFF
--- a/.github/holopin.yml
+++ b/.github/holopin.yml
@@ -1,0 +1,6 @@
+organization: dapr
+defaultSticker: clmjkxscc122740fl0mkmb7egi
+stickers:
+  -
+    id: clmjkxscc122740fl0mkmb7egi
+    alias: ghc2023


### PR DESCRIPTION
# Description

Add holopin config required to issue badges for the GHC2023 event.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/community/issues/351

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
