### PR TITLE
GitHub Workflows: update go version to v1.20

### DIFF
--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,5 +1,5 @@
-      DAPR_CLI_VERSION: 1.11.0
-      DAPR_RUNTIME_VERSION: 1.11.0
+      DAPR_CLI_VERSION: 1.12.0-rc.1
+      DAPR_RUNTIME_VERSION: 1.12.0-rc.3
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
       DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
       MACOS_PYTHON_VERSION: 3.10

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     env:
-      GOVER: 1.17
+      GOVER: 1.20
       KUBERNETES_VERSION: v1.21.1
       KIND_VERSION: v0.12.0
       KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6

--- a/.github/workflows/validate_csharp_quicstarts.yaml
+++ b/.github/workflows/validate_csharp_quicstarts.yaml
@@ -35,7 +35,7 @@ jobs:
     env:
       DAPR_DEFAULT_IMAGE_REGISTRY: GHCR
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
-      GOVER: 1.18
+      GOVER: 1.20
       KUBERNETES_VERSION: v1.25.3
       KIND_VERSION: v0.17.0
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1

--- a/.github/workflows/validate_go_quickstarts.yaml
+++ b/.github/workflows/validate_go_quickstarts.yaml
@@ -35,7 +35,7 @@ jobs:
     env:
       DAPR_DEFAULT_IMAGE_REGISTRY: GHCR
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
-      GOVER: 1.18
+      GOVER: '1.20'
       KUBERNETES_VERSION: v1.21.1
       KIND_VERSION: v0.11.0
       KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
@@ -76,7 +76,7 @@ jobs:
           sudo ln -s $(which podman) /usr/local/bin/docker
           sudo ln -s $(which podman-compose) /usr/local/bin/docker-compose
       - name: Set up Go ${{ env.GOVER }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GOVER }}
       - name: Set up Dapr CLI - Mac/Linux

--- a/.github/workflows/validate_java_quicstarts.yaml
+++ b/.github/workflows/validate_java_quicstarts.yaml
@@ -35,7 +35,7 @@ jobs:
     env:
       DAPR_DEFAULT_IMAGE_REGISTRY: GHCR
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
-      GOVER: 1.19
+      GOVER: 1.20
       KUBERNETES_VERSION: v1.25.3
       KIND_VERSION: v0.17.0
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1

--- a/.github/workflows/validate_javascript_quicstarts.yaml
+++ b/.github/workflows/validate_javascript_quicstarts.yaml
@@ -35,7 +35,7 @@ jobs:
     env:
       DAPR_DEFAULT_IMAGE_REGISTRY: GHCR
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
-      GOVER: 1.19
+      GOVER: 1.20
       KUBERNETES_VERSION: v1.25.3
       KIND_VERSION: v0.17.0
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1

--- a/.github/workflows/validate_python_quicstarts.yaml
+++ b/.github/workflows/validate_python_quicstarts.yaml
@@ -35,7 +35,7 @@ jobs:
     env:
       DAPR_DEFAULT_IMAGE_REGISTRY: GHCR
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install
-      GOVER: 1.19
+      GOVER: 1.20
       KUBERNETES_VERSION: v1.25.3
       KIND_VERSION: v0.17.0
       KIND_IMAGE_SHA: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1


### PR DESCRIPTION
This should also resolve the error we are seeing after upgrading Dapr to `1.12.0-rc.3` in tests.