### PR TITLE
Patching tests to pass (C# timing, Python uvicorn)

### DIFF
--- a/.github/workflows/validate_python_quicstarts.yaml
+++ b/.github/workflows/validate_python_quicstarts.yaml
@@ -99,6 +99,7 @@ jobs:
           echo "PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV
           pip3 install setuptools wheel
           pip3 install mechanical-markdown
+          pip3 install fastapi uvicorn
       - name: Validate building blocks with Python
         run: |
           variants=("http" "sdk")

--- a/pub_sub/csharp/http/README.md
+++ b/pub_sub/csharp/http/README.md
@@ -25,8 +25,8 @@ name: Run multi app run template
 expected_stdout_lines:
   - 'Started Dapr with app id "order-processor-http"'
   - 'Started Dapr with app id "checkout-http"'
-  - '== APP - checkout-http == Published data: Order { OrderId = 10 }'
-  - '== APP - order-processor-http == Subscriber received : 10'
+  - '== APP - checkout-http == Published data: Order { OrderId = 2 }'
+  - '== APP - order-processor-http == Subscriber received : 2'
 expected_stderr_lines:
 output_match_mode: substring
 match_order: none

--- a/pub_sub/csharp/sdk/README.md
+++ b/pub_sub/csharp/sdk/README.md
@@ -25,8 +25,8 @@ name: Run multi app run template
 expected_stdout_lines:
   - 'Started Dapr with app id "order-processor"'
   - 'Started Dapr with app id "checkout-sdk"'
-  - 'Published data: Order { OrderId = 10 }'
-  - 'Subscriber received : Order { OrderId = 10 }'
+  - 'Published data: Order { OrderId = 2 }'
+  - 'Subscriber received : Order { OrderId = 2 }'
 expected_stderr_lines:
 output_match_mode: substring
 match_order: none


### PR DESCRIPTION
# Description

Patching tests to pass (C# timing, Python uvicorn)
- C# chooses earlier item to not be in race condition with timeout
- Python pip3 installs fastapi and uvicorn and sets path, so uvicorn is found

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
