### PR TITLE
Update Pub-Sub C# - HTTP  README.md

### DIFF
--- a/pub_sub/csharp/http/README.md
+++ b/pub_sub/csharp/http/README.md
@@ -81,7 +81,7 @@ An alternative to running all or multiple applications at once is to run single 
 
 ```bash
 cd ./order-processor
-dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7005 -- dotnet run
+dapr run --app-id order-processor-http --resources-path ../../../components/ --app-port 7006 -- dotnet run
 ```
 
 ### Run Dotnet message publisher with Dapr


### PR DESCRIPTION
Changing the port number from 7005  to 7006 based on the port mentioned in pub_sub/csharp/sdk/order-processor/properties/launchSetting.json

# Description

Changed the port number from 7005 to 7006 based on the port mentioned in pub_sub/csharp/sdk/order-processor/properties/launchSetting.json

## Issue reference
#913 


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
