### PR TITLE
Fixes port 6003 conflict between Go Pub-sub and Go bindings.  

### DIFF
--- a/pub_sub/go/http/README.md
+++ b/pub_sub/go/http/README.md
@@ -77,7 +77,7 @@ An alternative to running all or multiple applications at once is to run single 
 
 ```bash
 cd ./order-processor
-dapr run --app-port 6003 --app-id order-processor-http --app-protocol http --dapr-http-port 3501 --resources-path ../../../components -- go run .
+dapr run --app-port 6007 --app-id order-processor-http --app-protocol http --dapr-http-port 3501 --resources-path ../../../components -- go run .
 ```
 
 ### Run Go message publisher with Dapr

--- a/pub_sub/go/http/dapr.yaml
+++ b/pub_sub/go/http/dapr.yaml
@@ -4,7 +4,7 @@ common:
 apps:
   - appID: order-processor-http
     appDirPath: ./order-processor/
-    appPort: 6003
+    appPort: 6007
     command: ["go", "run", "."]
   - appID: checkout-http
     appDirPath: ./checkout/


### PR DESCRIPTION
…issue

The timing of tests leads to conflict on port 6003

_Please explain the changes you've made_

## Issue reference

Current failed tests for Go

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
