### PR TITLE
Update app.js - `process.env.STATE_STORE_NAME`

### DIFF
--- a/tutorials/hello-kubernetes/node/app.js
+++ b/tutorials/hello-kubernetes/node/app.js
@@ -22,7 +22,7 @@ app.use(bodyParser.json());
 const daprPort = process.env.DAPR_HTTP_PORT ?? "3500"; 
 const daprGRPCPort = process.env.DAPR_GRPC_PORT ?? "50001";
 
-const stateStoreName = `statestore`;
+const stateStoreName = process.env.STATE_STORE_NAME ?? "statestore";
 const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
 const port = process.env.APP_PORT ?? "3000";
 


### PR DESCRIPTION
# Description

Allow to change the `STATE_STORE_NAME` for the Node app via an environment variable. Default still remain `statestore` if no value is supllied in this environment variable. So no side effect with existing behavior/configuration.

## Issue reference

None yet, let me know if you want I create one.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
* [X] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
