### PR TITLE
Clarified actor state persistence description

### DIFF
--- a/actors/csharp/sdk/service/SmokeDetectorActor.cs
+++ b/actors/csharp/sdk/service/SmokeDetectorActor.cs
@@ -36,7 +36,7 @@ internal class SmokeDetectorActor : Actor, ISmartDevice
     /// </summary>
     protected override Task OnDeactivateAsync()
     {
-        // Provides Opportunity to perform optional cleanup.
+        // Provides opportunity to perform optional cleanup.
         Console.WriteLine($"Deactivating actor id: {Id}");
         return Task.CompletedTask;
     }
@@ -47,9 +47,12 @@ internal class SmokeDetectorActor : Actor, ISmartDevice
     /// <param name="data">the user-defined MyData which will be stored into state store as "device_data" state</param>
     public async Task<string> SetDataAsync(SmartDeviceData data)
     {
-        // Data is saved to configured state store *implicitly* after each method execution by Actor's runtime.
-        // Data can also be saved *explicitly* by calling this.StateManager.SaveStateAsync();
-        // State to be saved must be DataContract serializable.
+        // All data operations performed on the actor are maintained against a per-actor cache and are not persisted
+        // to the actor state store until you've called `this.StateManager.SaveStateAsync();` Per the actor lifetime documentation,
+        // "If an actor is not used for a period of time, the Dapr actor runtime garbage-collects the in-memory object" meaning that 
+        // if you haven't persisted your changes to the underlying Dapr state store, your changes will be lost.
+
+        // Note also that all saved state must be DataContract serializable.
         await StateManager.SetStateAsync<SmartDeviceData>(
             deviceDataKey,
             data);

--- a/actors/csharp/sdk/service/SmokeDetectorActor.cs
+++ b/actors/csharp/sdk/service/SmokeDetectorActor.cs
@@ -47,10 +47,10 @@ internal class SmokeDetectorActor : Actor, ISmartDevice
     /// <param name="data">the user-defined MyData which will be stored into state store as "device_data" state</param>
     public async Task<string> SetDataAsync(SmartDeviceData data)
     {
-        // All data operations performed on the actor are maintained against a per-actor cache and are not persisted
-        // to the actor state store until you've called `this.StateManager.SaveStateAsync();` Per the actor lifetime documentation,
-        // "If an actor is not used for a period of time, the Dapr actor runtime garbage-collects the in-memory object" meaning that 
-        // if you haven't persisted your changes to the underlying Dapr state store, your changes will be lost.
+        // This set state action can happen along other state changing operations in each actor method and those changes will be maintained
+        // in a local cache to be committed as a single transaction to the backing store when the method has completed. As such, there is 
+        // no need to (and in fact makes your code less transactional) call `this.StateManager.SaveStateAsync()` as it will be automatically
+        // invoked by the actor runtime following the conclusion of this method as part of the internal `OnPostActorMethodAsyncInternal` method.
 
         // Note also that all saved state must be DataContract serializable.
         await StateManager.SetStateAsync<SmartDeviceData>(


### PR DESCRIPTION
# Description

The previous language used in the description in this quickstart was confusing and has spawned at least two questions about it that I've seen in the Discord channel. Updated to reflect that while changes to the state are made to the cache on a per-actor basis, but that an explicit call to `SaveStateAsync` is required to persist the state changes to the underlying actor state store.

I didn't make any code changes - just updated a comment in a method.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

None: Question raised in Discord.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
* [X] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
