### PR TITLE
Updating CI/CD actions to use release-1.13 of dapr/dapr runtime

### DIFF
--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,5 +1,5 @@
       DAPR_CLI_VERSION: 1.12.0
-      DAPR_RUNTIME_VERSION: 1.12.0
+      DAPR_RUNTIME_VERSION: 1.13.0-rc.1
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
       DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
       MACOS_PYTHON_VERSION: 3.10


### PR DESCRIPTION
# Description

Updates all CI/CD testing in the release branch to use updated 1.13 RC runtime release.
Needed for testing. 

## Issue reference

https://github.com/dapr/dapr/actions/runs/7802473423

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
