### PR TITLE
Fix tests broken by timing change

### DIFF
--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,5 +1,5 @@
       DAPR_CLI_VERSION: 1.12.0
-      DAPR_RUNTIME_VERSION: 1.13.0-rc.1
+      DAPR_RUNTIME_VERSION: 1.13.0-rc.2
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
       DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
       MACOS_PYTHON_VERSION: 3.10

--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,5 +1,5 @@
       DAPR_CLI_VERSION: 1.12.0
-      DAPR_RUNTIME_VERSION: 1.12.0
+      DAPR_RUNTIME_VERSION: 1.13.0-rc.1
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
       DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
       MACOS_PYTHON_VERSION: 3.10

--- a/bindings/components/binding-cron.yaml
+++ b/bindings/components/binding-cron.yaml
@@ -2,7 +2,6 @@ apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
   name: cron
-  namespace: quickstarts
 spec:
   type: bindings.cron
   version: v1

--- a/bindings/components/binding-postgres.yaml
+++ b/bindings/components/binding-postgres.yaml
@@ -2,7 +2,6 @@ apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
   name: sqldb
-  namespace: quickstarts
 spec:
   type: bindings.postgres
   version: v1

--- a/state_management/csharp/http/README.md
+++ b/state_management/csharp/http/README.md
@@ -74,8 +74,8 @@ sleep: 15
 cd ./order-processor
 dapr run --app-id order-processor --resources-path ../../../resources/ -- dotnet run
 ```
+<!-- END_STEP -->
 
 2. Stop and clean up application processes
 
 dapr stop --app-id order-processor
-<!-- END_STEP -->

--- a/state_management/csharp/sdk/README.md
+++ b/state_management/csharp/sdk/README.md
@@ -87,8 +87,10 @@ You're up and running! Both Dapr and your app logs will appear here.
 == APP == Getting Order: Order { orderId = 3 }
 == APP == Deleting Order: Order { orderId = 3 }
 ```
+<!-- END_STEP -->
 
 2. Stop and clean up application processes
 
+```bash
 dapr stop --app-id order-processor
-<!-- END_STEP -->
+```

--- a/state_management/go/http/README.md
+++ b/state_management/go/http/README.md
@@ -79,8 +79,9 @@ You're up and running! Both Dapr and your app logs will appear here.
 == APP == Retrieved Order: "{\"orderId\":3}"
 == APP == 2023/09/24 23:31:27 Deleted Order: {"orderId":3}
 ```
+<!-- END_STEP -->
 
 2. Stop and clean up application processes
+```bash
 dapr stop --app-id order-processor
-
-<!-- END_STEP -->
+```

--- a/state_management/go/sdk/README.md
+++ b/state_management/go/sdk/README.md
@@ -76,8 +76,9 @@ You're up and running! Both Dapr and your app logs will appear here.
 		== APP - order-processor == Retrieved Order: {"orderId":2}
 		== APP - order-processor == Deleted Order: {"orderId":2}
 ```
+<!-- END_STEP -->
 
 2. Stop and clean up application processes
+```bash
 dapr stop --app-id order-processor
-
-<!-- END_STEP -->
+```

--- a/state_management/javascript/sdk/README.md
+++ b/state_management/javascript/sdk/README.md
@@ -88,10 +88,11 @@ sleep: 60
 ```bash
 dapr run --app-id order-processor --resources-path ../../../resources/ -- npm start
 ```
+<!-- END_STEP -->
 
 2. Stop and cleanup the process
 
 ```bash
 dapr stop --app-id order-processor
 ```
-<!-- END_STEP -->
+


### PR DESCRIPTION
# Description

Tests now fail in state management CI/CD because of the final `dapr stop` on the single service.  in 1.12.0 the service was still available to stop by the time this step ran.  Now, the service is already gone, so stop fails.  The fix is to keep the stop in the readme, but remove it from the test workflow which will run it in CI.  

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
