### PR TITLE
Fix the DAPR bot script addressing this issue #966

### DIFF
--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -32,7 +32,7 @@ jobs:
             const commentBody = payload.comment.body;
             if (!isFromPulls && commentBody && commentBody.indexOf("/assign") == 0) {
               if (!issue.assignees || issue.assignees.length === 0) {
-                await github.issues.addAssignees({
+                await github.rest.issues.addAssignees({
                   owner: issue.owner,
                   repo: issue.repo,
                   issue_number: issue.number,


### PR DESCRIPTION
# Description

Starting V5 of Github actions, there is a change in the rest end points.  github.issues.** has changed to github.rest.issues**; hence dapr bot is not functioning for some of these actions.  
 
Reference: https://github.com/actions/github-script#breaking-changes-in-v5

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #966 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
