### PR TITLE
Convert to net8 on release 1.13

### DIFF
--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,5 +1,5 @@
       DAPR_CLI_VERSION: 1.12.0
-      DAPR_RUNTIME_VERSION: 1.13.0-rc.2
+      DAPR_RUNTIME_VERSION: 1.13.0-rc.4
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
       DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
       MACOS_PYTHON_VERSION: 3.10

--- a/.github/workflows/validate_csharp_quicstarts.yaml
+++ b/.github/workflows/validate_csharp_quicstarts.yaml
@@ -79,7 +79,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            7.0.x
+            6.0.x
+            8.0.x
       - name: Set up Dapr CLI - Mac/Linux
         if: matrix.os != 'windows-latest'
         run: wget -q ${{ env.DAPR_INSTALL_URL }}/install.sh -O - | /bin/bash -s ${{ env.DAPR_CLI_VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ release.properties
 mvnw
 packages
 **/__pycache__/
+Debug/
 
 # IDE generated files and directories
 *.iml

--- a/actors/csharp/sdk/README.md
+++ b/actors/csharp/sdk/README.md
@@ -34,15 +34,15 @@ Run the `SmartDevice.Service`, which will start service itself and the Dapr side
 <!-- STEP
 name: Run actor service
 expected_stdout_lines:
-  - "Request finished HTTP/1.1 GET http://127.0.0.1:5001/healthz - - - 200"
+  - "Request finished HTTP/1.1 GET http://127.0.0.1:5001/healthz - 200"
 expected_stderr_lines:
-working_dir: ./service
+working_dir: .
 output_match_mode: substring
 background: true
 sleep: 30
 -->
 ```bash
-cd actors/csharp/sdk/service
+cd service
 dapr run --app-id actorservice --app-port 5001 --app-protocol http --dapr-http-port 56001 --resources-path ../../../resources -- dotnet run --urls=http://localhost:5001/
 ```
 <!-- END_STEP -->
@@ -70,13 +70,13 @@ name: Run actor client
 expected_stdout_lines:
   - "Device 2 state: Location: Second Floor, Status: Ready"
 expected_stderr_lines:
-working_dir: ./client
+working_dir: .
 output_match_mode: substring
 background: true
 sleep: 60
 -->
 ```bash
-cd ./actors/csharp/sdk/client
+cd client
 dapr run --app-id actorclient -- dotnet run
 ```
 <!-- END_STEP -->

--- a/actors/csharp/sdk/client/SmartDevice.Client.csproj
+++ b/actors/csharp/sdk/client/SmartDevice.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>

--- a/actors/csharp/sdk/interfaces/SmartDevice.Interfaces.csproj
+++ b/actors/csharp/sdk/interfaces/SmartDevice.Interfaces.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/actors/csharp/sdk/sdk.sln
+++ b/actors/csharp/sdk/sdk.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartDevice.Service", "service\SmartDevice.Service.csproj", "{3E9760D4-A707-487F-8B73-3ECB080749C0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartDevice.Client", "client\SmartDevice.Client.csproj", "{044F6311-35DC-4A94-A99A-35CB59913AFF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartDevice.Interfaces", "interfaces\SmartDevice.Interfaces.csproj", "{D5B9AFF1-D7F3-42E5-8E8E-06593F91323F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3E9760D4-A707-487F-8B73-3ECB080749C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E9760D4-A707-487F-8B73-3ECB080749C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E9760D4-A707-487F-8B73-3ECB080749C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E9760D4-A707-487F-8B73-3ECB080749C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{044F6311-35DC-4A94-A99A-35CB59913AFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{044F6311-35DC-4A94-A99A-35CB59913AFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{044F6311-35DC-4A94-A99A-35CB59913AFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{044F6311-35DC-4A94-A99A-35CB59913AFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5B9AFF1-D7F3-42E5-8E8E-06593F91323F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5B9AFF1-D7F3-42E5-8E8E-06593F91323F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5B9AFF1-D7F3-42E5-8E8E-06593F91323F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5B9AFF1-D7F3-42E5-8E8E-06593F91323F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {409D8B04-7025-42BC-BC2A-AF3F6A089623}
+	EndGlobalSection
+EndGlobal

--- a/actors/csharp/sdk/service/SmartDevice.Service.csproj
+++ b/actors/csharp/sdk/service/SmartDevice.Service.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/bindings/csharp/http/batch/batch.csproj
+++ b/bindings/csharp/http/batch/batch.csproj
@@ -2,13 +2,9 @@
 
     <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
-  
-    <ItemGroup>
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    </ItemGroup>
 
   </Project>

--- a/bindings/csharp/sdk/batch/batch.csproj
+++ b/bindings/csharp/sdk/batch/batch.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>net7.0</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/bindings/csharp/sdk/batch/batch.csproj
+++ b/bindings/csharp/sdk/batch/batch.csproj
@@ -2,13 +2,12 @@
 
     <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
   
     <ItemGroup>
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
       <PackageReference Include="Dapr.AspNetCore" Version="1.12.*-*" />
     </ItemGroup>
 

--- a/configuration/csharp/http/order-processor/Program.csproj
+++ b/configuration/csharp/http/order-processor/Program.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/configuration/csharp/sdk/order-processor/Program.csproj
+++ b/configuration/csharp/sdk/order-processor/Program.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pub_sub/csharp/http/checkout/checkout.csproj
+++ b/pub_sub/csharp/http/checkout/checkout.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/pub_sub/csharp/http/order-processor/order-processor.csproj
+++ b/pub_sub/csharp/http/order-processor/order-processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/pub_sub/csharp/sdk/checkout/checkout.csproj
+++ b/pub_sub/csharp/sdk/checkout/checkout.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pub_sub/csharp/sdk/order-processor/order-processor.csproj
+++ b/pub_sub/csharp/sdk/order-processor/order-processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/secrets_management/csharp/http/order-processor/Program.csproj
+++ b/secrets_management/csharp/http/order-processor/Program.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/secrets_management/csharp/sdk/order-processor/Program.csproj
+++ b/secrets_management/csharp/sdk/order-processor/Program.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/service_invocation/csharp/http/checkout/checkout.csproj
+++ b/service_invocation/csharp/http/checkout/checkout.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/service_invocation/csharp/http/order-processor/order-processor.csproj
+++ b/service_invocation/csharp/http/order-processor/order-processor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/state_management/csharp/http/order-processor/Program.csproj
+++ b/state_management/csharp/http/order-processor/Program.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/state_management/csharp/sdk/order-processor/Program.csproj
+++ b/state_management/csharp/sdk/order-processor/Program.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tutorials/pub-sub/csharp-subscriber/csharp-subscriber.csproj
+++ b/tutorials/pub-sub/csharp-subscriber/csharp-subscriber.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/workflows/csharp/sdk/order-processor/WorkflowConsoleApp.csproj
+++ b/workflows/csharp/sdk/order-processor/WorkflowConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <NoWarn>612,618</NoWarn>


### PR DESCRIPTION
# Description

Converted quickstart projects to use .Net 8 runtime and SDK in all C# projects.

## Issue reference

Please reference the issue this PR will close: #980

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
