### PR TITLE
Updating to RC6 which has fix to #982

### DIFF
--- a/.github/env/global.env
+++ b/.github/env/global.env
@@ -1,5 +1,5 @@
       DAPR_CLI_VERSION: 1.12.0
-      DAPR_RUNTIME_VERSION: 1.13.0-rc.4
+      DAPR_RUNTIME_VERSION: 1.13.0-rc.6
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/v${DAPR_CLI_VERSION}/install/
       DAPR_DEFAULT_IMAGE_REGISTRY: ghcr
       MACOS_PYTHON_VERSION: 3.10

--- a/bindings/components/binding-cron.yaml
+++ b/bindings/components/binding-cron.yaml
@@ -2,6 +2,7 @@ apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
   name: cron
+  namespace: quickstarts
 spec:
   type: bindings.cron
   version: v1

--- a/bindings/components/binding-postgres.yaml
+++ b/bindings/components/binding-postgres.yaml
@@ -2,6 +2,7 @@ apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
   name: sqldb
+  namespace: quickstarts
 spec:
   type: bindings.postgres
   version: v1


### PR DESCRIPTION
# Description

Updating to RC6 which has fix to #982
Restoring `quickstarts` namespaces in components

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #982 and https://github.com/dapr/dapr/issues/7523

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
