### PR TITLE
Test fix: Removing `toolchain go*` lines that cause midstream downloads

### DIFF
--- a/state_management/go/sdk/order-processor/go.mod
+++ b/state_management/go/sdk/order-processor/go.mod
@@ -2,8 +2,6 @@ module order_processor_sdk_example
 
 go 1.21
 
-toolchain go1.22.0
-
 require github.com/dapr/go-sdk v1.10.0-rc-1
 
 require (

--- a/workflows/go/sdk/order-processor/go.mod
+++ b/workflows/go/sdk/order-processor/go.mod
@@ -2,8 +2,6 @@ module dapr_example
 
 go 1.21
 
-toolchain go1.21.6
-
 require github.com/dapr/go-sdk v1.10.0-rc-1
 
 require (


### PR DESCRIPTION
What happened is the go tools inserted toolchain go1.22.0 into go.mod, and that forced the automated test to midstream download go.1.22.0 (because they are based on go 1.21.0) and that is what munged the text output.  

This hint was deep in the logs on line 937 where you see `downloading go1.22.0`.  
https://github.com/dapr/quickstarts/actions/runs/8089746951/job/22106150891#step:12:928

```
		== APP - order-processor == go: downloading go1.22.0 (linux/amd64)
```

