### PR TITLE
Updated Javascript quickstarts with nightly dapr-dev (RC compatible) …

### DIFF
--- a/bindings/javascript/sdk/batch/index.js
+++ b/bindings/javascript/sdk/batch/index.js
@@ -15,7 +15,7 @@ limitations under the License.
 dapr run --app-id batch-sdk --app-port 5002 --dapr-http-port 3500 --resources-path ../../../components -- node index.js
 */
 
-import { DaprClient, DaprServer } from "@dapr/dapr";
+import { DaprClient, DaprServer } from "@dapr/dapr-dev";
 import fs from 'fs';
 
 const cronBindingName = "cron";

--- a/bindings/javascript/sdk/batch/package.json
+++ b/bindings/javascript/sdk/batch/package.json
@@ -8,7 +8,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@dapr/dapr": "^3.2.0",
+        "@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb",
         "axios": "^0.25.0"
     }
 }

--- a/configuration/javascript/sdk/order-processor/index.js
+++ b/configuration/javascript/sdk/order-processor/index.js
@@ -1,4 +1,4 @@
-import { CommunicationProtocolEnum, DaprClient } from "@dapr/dapr";
+import { CommunicationProtocolEnum, DaprClient } from "@dapr/dapr-dev";
 
 // JS SDK does not support Configuration API over HTTP protocol yet
 const communicationProtocol = CommunicationProtocolEnum.GRPC;

--- a/configuration/javascript/sdk/order-processor/package.json
+++ b/configuration/javascript/sdk/order-processor/package.json
@@ -11,7 +11,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@dapr/dapr": "^3.2.0"
+        "@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb"
     },
     "devDependencies": {
         "eslint": "^8.8.0",

--- a/cryptography/javascript/sdk/crypto-quickstart/index.mjs
+++ b/cryptography/javascript/sdk/crypto-quickstart/index.mjs
@@ -2,7 +2,7 @@ import { createReadStream, createWriteStream } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
 
-import { DaprClient, CommunicationProtocolEnum } from "@dapr/dapr";
+import { DaprClient, CommunicationProtocolEnum } from "@dapr/dapr-dev";
 
 const daprHost = process.env.DAPR_HOST ?? "127.0.0.1";
 const daprPort = process.env.DAPR_GRPC_PORT ?? "50001";

--- a/cryptography/javascript/sdk/crypto-quickstart/package.json
+++ b/cryptography/javascript/sdk/crypto-quickstart/package.json
@@ -12,7 +12,7 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "@dapr/dapr": "^3.2.0"
+        "@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb"
     },
     "devDependencies": {
         "@types/node": "^18.0.0",

--- a/pub_sub/javascript/sdk/checkout/index.js
+++ b/pub_sub/javascript/sdk/checkout/index.js
@@ -1,4 +1,4 @@
-import { DaprClient } from "@dapr/dapr";
+import { DaprClient } from "@dapr/dapr-dev";
 
 const daprHost = process.env.DAPR_HOST || "http://localhost";
 const daprPort = process.env.DAPR_HTTP_PORT || "3500";

--- a/pub_sub/javascript/sdk/checkout/package.json
+++ b/pub_sub/javascript/sdk/checkout/package.json
@@ -12,6 +12,6 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@dapr/dapr": "^3.2.0"
+        "@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb"
     }
 }

--- a/pub_sub/javascript/sdk/order-processor/index.js
+++ b/pub_sub/javascript/sdk/order-processor/index.js
@@ -1,4 +1,4 @@
-import { DaprServer } from "@dapr/dapr";
+import { DaprServer } from "@dapr/dapr-dev";
 
 const daprHost = process.env.DAPR_HOST || "http://localhost";
 const daprPort = process.env.DAPR_HTTP_PORT || "3501";

--- a/pub_sub/javascript/sdk/order-processor/package.json
+++ b/pub_sub/javascript/sdk/order-processor/package.json
@@ -12,6 +12,6 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@dapr/dapr": "^3.2.0"
+        "@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb"
     }
 }

--- a/secrets_management/javascript/sdk/order-processor/index.js
+++ b/secrets_management/javascript/sdk/order-processor/index.js
@@ -1,4 +1,4 @@
-import { DaprClient, CommunicationProtocolEnum } from '@dapr/dapr';
+import { DaprClient, CommunicationProtocolEnum } from '@dapr/dapr-dev';
 
 const daprHost = process.env.DAPR_HOST || "http://localhost";
 const daprPort = process.env.DAPR_HTTP_PORT || "3500";

--- a/secrets_management/javascript/sdk/order-processor/package-lock.json
+++ b/secrets_management/javascript/sdk/order-processor/package-lock.json
@@ -9,20 +9,21 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@dapr/dapr": "^3.2.0"
+                "@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb"
             },
             "devDependencies": {
                 "eslint": "^8.8.0",
                 "eslint-plugin-react": "^7.28.0"
             }
         },
-        "node_modules/@dapr/dapr": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.2.0.tgz",
-            "integrity": "sha512-+gvCDtzCfIww4117pLA2xmkAGosz8atkoC8e/cHKEiQ2iK/3+mahMkTsJmmVwAv6/tSxa50faRsHo5hpUJyCmQ==",
+        "node_modules/@dapr/dapr-dev": {
+            "version": "3.2.0-20240212030427-319e2fb",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr-dev/-/dapr-dev-3.2.0-20240212030427-319e2fb.tgz",
+            "integrity": "sha512-TEdNz7Y3L5X15YzEQ+4RHh0sPaiySWlFpYhrmXV3kipFP9vGFq+bp8kdBdm+yOqYe6v1ix3/kxyypKqQMxbA5Q==",
             "dependencies": {
                 "@grpc/grpc-js": "^1.9.3",
                 "@js-temporal/polyfill": "^0.3.0",
+                "@microsoft/durabletask-js": "^0.1.0-alpha.1",
                 "@types/google-protobuf": "^3.15.5",
                 "@types/node-fetch": "^2.6.2",
                 "body-parser": "^1.19.0",
@@ -166,6 +167,15 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@microsoft/durabletask-js": {
+            "version": "0.1.0-alpha.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/durabletask-js/-/durabletask-js-0.1.0-alpha.1.tgz",
+            "integrity": "sha512-wdBCz86FCj2lknLqyjU+J0Auetxxr7vj0SUjPjnjxRaE0VrM4G3WmX65XDlsligoIg2JEe0M89REzaA6IVh4pw==",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.8.14",
+                "google-protobuf": "^3.21.2"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -1235,9 +1245,9 @@
             }
         },
         "node_modules/google-protobuf": {
-            "version": "3.19.4",
-            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.4.tgz",
-            "integrity": "sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg=="
+            "version": "3.21.2",
+            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+            "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -2667,13 +2677,14 @@
         }
     },
     "dependencies": {
-        "@dapr/dapr": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.2.0.tgz",
-            "integrity": "sha512-+gvCDtzCfIww4117pLA2xmkAGosz8atkoC8e/cHKEiQ2iK/3+mahMkTsJmmVwAv6/tSxa50faRsHo5hpUJyCmQ==",
+        "@dapr/dapr-dev": {
+            "version": "3.2.0-20240212030427-319e2fb",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr-dev/-/dapr-dev-3.2.0-20240212030427-319e2fb.tgz",
+            "integrity": "sha512-TEdNz7Y3L5X15YzEQ+4RHh0sPaiySWlFpYhrmXV3kipFP9vGFq+bp8kdBdm+yOqYe6v1ix3/kxyypKqQMxbA5Q==",
             "requires": {
                 "@grpc/grpc-js": "^1.9.3",
                 "@js-temporal/polyfill": "^0.3.0",
+                "@microsoft/durabletask-js": "^0.1.0-alpha.1",
                 "@types/google-protobuf": "^3.15.5",
                 "@types/node-fetch": "^2.6.2",
                 "body-parser": "^1.19.0",
@@ -2784,6 +2795,15 @@
             "requires": {
                 "big-integer": "^1.6.51",
                 "tslib": "^2.3.1"
+            }
+        },
+        "@microsoft/durabletask-js": {
+            "version": "0.1.0-alpha.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/durabletask-js/-/durabletask-js-0.1.0-alpha.1.tgz",
+            "integrity": "sha512-wdBCz86FCj2lknLqyjU+J0Auetxxr7vj0SUjPjnjxRaE0VrM4G3WmX65XDlsligoIg2JEe0M89REzaA6IVh4pw==",
+            "requires": {
+                "@grpc/grpc-js": "^1.8.14",
+                "google-protobuf": "^3.21.2"
             }
         },
         "@protobufjs/aspromise": {
@@ -3609,9 +3629,9 @@
             }
         },
         "google-protobuf": {
-            "version": "3.19.4",
-            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.4.tgz",
-            "integrity": "sha512-OIPNCxsG2lkIvf+P5FNfJ/Km95CsXOBecS9ZcAU6m2Rq3svc0Apl9nB3GMDNKfQ9asNv4KjyAqGwPQFrVle3Yg=="
+            "version": "3.21.2",
+            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+            "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
         },
         "has": {
             "version": "1.0.3",

--- a/secrets_management/javascript/sdk/order-processor/package.json
+++ b/secrets_management/javascript/sdk/order-processor/package.json
@@ -12,7 +12,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@dapr/dapr": "^3.2.0"
+        "@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb"
     },
     "devDependencies": {
         "eslint": "^8.8.0",

--- a/state_management/javascript/sdk/order-processor/index.js
+++ b/state_management/javascript/sdk/order-processor/index.js
@@ -1,4 +1,4 @@
-import { CommunicationProtocolEnum, DaprClient } from "@dapr/dapr"
+import { CommunicationProtocolEnum, DaprClient } from "@dapr/dapr-dev"
 
 const communicationProtocol = (process.env.DAPR_PROTOCOL === "grpc")
     ? CommunicationProtocolEnum.GRPC

--- a/state_management/javascript/sdk/order-processor/package.json
+++ b/state_management/javascript/sdk/order-processor/package.json
@@ -12,10 +12,10 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@dapr/dapr": "^3.2.0"
+        "@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb"
     },
     "devDependencies": {
-        "eslint": "^8.8.0",
-        "eslint-plugin-react": "^7.28.0"
+        "eslint": "^8.57.0",
+        "eslint-plugin-react": "^7.33.2"
     }
 }


### PR DESCRIPTION
Testing with the following package as a proxy for an RC release of javascript-sdk
`"@dapr/dapr-dev": "^3.2.0-20240212030427-319e2fb"`

Note I had to update all of these to make it work:
-package.json *
-index.js * references to @dapr/dapr

And we'll have to revert this back for final release.