### PR TITLE
add missing body-parser package to js pub_sub order-processor

### DIFF
--- a/pub_sub/javascript/http/order-processor/package.json
+++ b/pub_sub/javascript/http/order-processor/package.json
@@ -12,6 +12,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "express": "^4.17.2"
+        "express": "^4.17.2",
+        "body-parser": "^1.19.0"
     }
 }


### PR DESCRIPTION
# Description

pub_sub quick start projects crashes with:
`== APP - order-processor-http == Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'body-parser' `

The PR adds body-parser version ^1.19.0 - the newest one used in other quick start projects

## Issue reference

No related issue created
