### PR TITLE
Update holopin.yml to award Quickstarts badge to contributors

### DIFF
--- a/.github/holopin.yml
+++ b/.github/holopin.yml
@@ -1,6 +1,6 @@
 organization: dapr
-defaultSticker: clmjkxscc122740fl0mkmb7egi
+defaultSticker: clrqfb88y222860gjxdlaobhpt
 stickers:
   -
-    id: clmjkxscc122740fl0mkmb7egi
-    alias: ghc2023
+    id: clrqfb88y222860gjxdlaobhpt
+    alias: quickstarts-badge


### PR DESCRIPTION
# Description

The `yaml` file to award contribution badges has been updated such that each contributor can be awarded a Quickstarts badge for their contribution to this repo.

## Issue reference

This PR fixes #1004 

### Please reference the issue this PR will close: #1004 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly.
* [x] Correct and accurate change has been done as per the issue suggestion.
* [x] YAML doesn't throw any error.