### PR TITLE
Updating `hello-kubernetes` quickstart to support Endpoint env vars

### DIFF
--- a/tutorials/hello-kubernetes/node/app.js
+++ b/tutorials/hello-kubernetes/node/app.js
@@ -19,11 +19,11 @@ const app = express();
 app.use(bodyParser.json());
 
 // These ports are injected automatically into the container.
-const daprPort = process.env.DAPR_HTTP_PORT ?? "3500"; 
-const daprGRPCPort = process.env.DAPR_GRPC_PORT ?? "50001";
+const daprHttpEndpoint = process.env.DAPR_HTTP_ENDPOINT ?? "http://localhost:3500"; 
+const daprGRPCEndpoint = process.env.DAPR_GRPC_ENDPOINT ?? "http://localhost:50001";
 
 const stateStoreName = process.env.STATE_STORE_NAME ?? "statestore";
-const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
+const stateUrl = `${daprHttpEndpoint}/v1.0/state/${stateStoreName}`;
 const port = process.env.APP_PORT ?? "3000";
 
 app.get('/order', async (_req, res) => {
@@ -71,9 +71,9 @@ app.post('/neworder', async (req, res) => {
 });
 
 app.get('/ports', (_req, res) => {
-    console.log("DAPR_HTTP_PORT: " + daprPort);
-    console.log("DAPR_GRPC_PORT: " + daprGRPCPort);
-    res.status(200).send({DAPR_HTTP_PORT: daprPort, DAPR_GRPC_PORT: daprGRPCPort })
+    console.log("DAPR_HTTP_ENDPOINT: " + daprHttpEndpoint);
+    console.log("DAPR_GRPC_ENDPOINT: " + daprGRPCEndpoint);
+    res.status(200).send({DAPR_HTTP_ENDPOINT: daprHttpEndpoint, DAPR_GRPC_ENDPOINT: daprGRPCEndpoint })
 });
 
 app.listen(port, () => console.log(`Node App listening on port ${port}!`));

--- a/tutorials/hello-kubernetes/python/app.py
+++ b/tutorials/hello-kubernetes/python/app.py
@@ -15,8 +15,8 @@ import os
 import requests
 import time
 
-dapr_port = os.getenv("DAPR_HTTP_PORT", 3500)
-dapr_url = "http://localhost:{}/neworder".format(dapr_port)
+dapr_http_endpoint = os.getenv("DAPR_HTTP_ENDPOINT", "http://localhost:3500")
+dapr_url = "{}/neworder".format(dapr_http_endpoint)
 
 n = 0
 while True:


### PR DESCRIPTION
# Description

I've updated the examples to use the DAPR_HTTP_ENDPOINT and DAPR_GRPC_ENDPOINT environment variables that are used by the SDKs. If DAPR_HTTP_PORT needs to be also supported I will need some help to validate the code. 

I am not sure how images are created for these applications, help is appreciated to validate these changes.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1029 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
