### PR TITLE
feat: upgraded springboot to 3.3.1 and bumped up other dependencies

### DIFF
--- a/bindings/java/http/batch/pom.xml
+++ b/bindings/java/http/batch/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.3</version>
+		<version>3.3.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.service</groupId>
@@ -19,12 +19,12 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20211205</version>
+			<version>20240303</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.0</version>
+			<version>2.17.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.32</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>
@@ -42,7 +42,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>2.6.4</version>
+				<version>3.3.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/bindings/java/sdk/batch/pom.xml
+++ b/bindings/java/sdk/batch/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.3</version>
+		<version>3.3.1</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.service</groupId>
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>4.9.0</version>
+			<version>4.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -38,13 +38,13 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.32</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.0</version>
+			<version>2.17.1</version>
 		</dependency>
 	</dependencies>
 
@@ -53,12 +53,12 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>2.6.4</version>
+				<version>3.3.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.3.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/configuration/java/http/README.md
+++ b/configuration/java/http/README.md
@@ -13,10 +13,10 @@ This quickstart includes one service:
 ## Prerequisites
 
 - [Maven 3.x](https://maven.apache.org/install.html)
-- Java JDK 11 (or greater):
-  - [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
-  - [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)
-  - [OpenJDK 11](https://jdk.java.net/11/)
+- Java JDK 17 (or greater):
+  - [Microsoft JDK 17](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17)
+  - [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/?er=221886#java17)
+  - [OpenJDK 17](https://jdk.java.net/17/)
 - Locally running redis container - a redis container named `dapr_redis` is automatically created when you run `dapr init`
 
 ## Add configuration items to the config store

--- a/configuration/java/http/order-processor/pom.xml
+++ b/configuration/java/http/order-processor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.3</version>
+        <version>3.3.1</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20220924</version>
+            <version>20240303</version>
         </dependency>
     </dependencies>
     <build>
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.4</version>
+                <version>3.3.1</version>
             </plugin>
         </plugins>
     </build>

--- a/configuration/java/sdk/README.md
+++ b/configuration/java/sdk/README.md
@@ -11,10 +11,10 @@ This quickstart includes one service:
 ## Prerequisites
 
 - [Maven 3.x](https://maven.apache.org/install.html)
-- Java JDK 11 (or greater):
-  - [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
-  - [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)
-  - [OpenJDK 11](https://jdk.java.net/11/)
+- Java JDK 17 (or greater):
+  - [Microsoft JDK 17](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17)
+  - [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/?er=221886#java17)
+  - [OpenJDK 17](https://jdk.java.net/17/)
 - Locally running redis container - a redis container named `dapr_redis` is automatically created when you run `dapr init`
 
 ## Add configuration items to the config store

--- a/configuration/java/sdk/order-processor/pom.xml
+++ b/configuration/java/sdk/order-processor/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <slf4jVersion>1.6.1</slf4jVersion>
+        <slf4jVersion>2.0.13</slf4jVersion>
     </properties>
     <dependencies>
         <dependency>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.4.0</version>
+            <version>3.6.7</version>
         </dependency>
     </dependencies>
 
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.3</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/configuration/java/sdk/order-processor/src/main/java/com/service/OrderProcessingServiceApplication.java
+++ b/configuration/java/sdk/order-processor/src/main/java/com/service/OrderProcessingServiceApplication.java
@@ -1,7 +1,6 @@
 package com.service;
 
 import io.dapr.client.DaprClientBuilder;
-import io.dapr.client.DaprPreviewClient;
 import io.dapr.client.DaprClient;
 import io.dapr.client.domain.ConfigurationItem;
 import io.dapr.client.domain.SubscribeConfigurationResponse;

--- a/pub_sub/java/http/README.md
+++ b/pub_sub/java/http/README.md
@@ -17,10 +17,10 @@ And one subscriber:
 ## Pre-requisites
 
 * [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr-cli/).
-* Java JDK 11 (or greater):
-    * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
-    * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)
-    * [OpenJDK 11](https://jdk.java.net/11/)
+* Java JDK 17 (or greater):
+  * [Microsoft JDK 17](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17)
+  * [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/?er=221886#java17)
+  * [OpenJDK 17](https://jdk.java.net/17/)
 * [Apache Maven](https://maven.apache.org/install.html) version 3.x.
 
 ## Run all apps with multi-app run template file:

--- a/pub_sub/java/http/checkout/pom.xml
+++ b/pub_sub/java/http/checkout/pom.xml
@@ -11,13 +11,13 @@
 	<properties>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
-		<slf4jVersion>1.6.1</slf4jVersion>
+		<slf4jVersion>2.0.13</slf4jVersion>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20211205</version>
+			<version>20240303</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -35,7 +35,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>2.6.4</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pub_sub/java/http/order-processor/pom.xml
+++ b/pub_sub/java/http/order-processor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.3</version>
+		<version>3.3.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.service</groupId>
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.32</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>2.6.4</version>
+				<version>3.3.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/pub_sub/java/sdk/README.md
+++ b/pub_sub/java/sdk/README.md
@@ -17,10 +17,10 @@ And one subscriber:
 ## Pre-requisites
 
 * [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr-cli/).
-* Java JDK 11 (or greater):
-    * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
-    * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)
-    * [OpenJDK 11](https://jdk.java.net/11/)
+* Java JDK 17 (or greater):
+  * [Microsoft JDK 17](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17)
+  * [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/?er=221886#java17)
+  * [OpenJDK 17](https://jdk.java.net/17/)
 * [Apache Maven](https://maven.apache.org/install.html) version 3.x.
 
 ## Run all apps with multi-app run template file:

--- a/pub_sub/java/sdk/checkout/pom.xml
+++ b/pub_sub/java/sdk/checkout/pom.xml
@@ -11,7 +11,7 @@
 	<properties>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
-		<slf4jVersion>1.6.1</slf4jVersion>
+		<slf4jVersion>2.0.13</slf4jVersion>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>4.9.0</version>
+			<version>4.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.32</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>2.6.4</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pub_sub/java/sdk/order-processor/pom.xml
+++ b/pub_sub/java/sdk/order-processor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.3</version>
+		<version>3.3.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.service</groupId>
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.32</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>
@@ -44,12 +44,12 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>2.6.4</version>
+				<version>3.3.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.3.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/secrets_management/java/http/order-processor/pom.xml
+++ b/secrets_management/java/http/order-processor/pom.xml
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.3</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/secrets_management/java/sdk/order-processor/pom.xml
+++ b/secrets_management/java/sdk/order-processor/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.3</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/service_invocation/java/http/README.md
+++ b/service_invocation/java/http/README.md
@@ -15,10 +15,10 @@ And one order processor service:
 ## Pre-requisites
 
 * [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr-cli/).
-* Java JDK 11 (or greater):
-    * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
-    * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)
-    * [OpenJDK 11](https://jdk.java.net/11/)
+* Java JDK 17 (or greater):
+  * [Microsoft JDK 17](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17)
+  * [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/?er=221886#java17)
+  * [OpenJDK 17](https://jdk.java.net/17/)
 * [Apache Maven](https://maven.apache.org/install.html) version 3.x.
 
 ## Run all apps with multi-app run template file:

--- a/service_invocation/java/http/checkout/pom.xml
+++ b/service_invocation/java/http/checkout/pom.xml
@@ -11,13 +11,13 @@
 	<properties>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
-		<slf4jVersion>1.6.1</slf4jVersion>
+		<slf4jVersion>2.0.13</slf4jVersion>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20211205</version>
+			<version>20240303</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -25,7 +25,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>2.6.3</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/service_invocation/java/http/order-processor/pom.xml
+++ b/service_invocation/java/http/order-processor/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.3</version>
+		<version>3.3.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.service</groupId>

--- a/state_management/java/http/README.md
+++ b/state_management/java/http/README.md
@@ -9,10 +9,10 @@ Visit [this](https://docs.dapr.io/developing-applications/building-blocks/state-
 ## Pre-requisites
 
 * [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr-cli/).
-* Java JDK 11 (or greater):
-  * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
-  * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)
-  * [OpenJDK 11](https://jdk.java.net/11/)
+* Java JDK 17 (or greater):
+  * [Microsoft JDK 17](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17)
+  * [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/?er=221886#java17)
+  * [OpenJDK 17](https://jdk.java.net/17/)
 * [Apache Maven](https://maven.apache.org/install.html) version 3.x.
 
 This quickstart includes one service: Java client service `order-processor`

--- a/state_management/java/http/order-processor/pom.xml
+++ b/state_management/java/http/order-processor/pom.xml
@@ -12,19 +12,19 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <slf4jVersion>1.6.1</slf4jVersion>
+        <slf4jVersion>2.0.13</slf4jVersion>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.32</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.17.1</version>
         </dependency>
     </dependencies>
     <build>
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.3</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/state_management/java/sdk/README.md
+++ b/state_management/java/sdk/README.md
@@ -9,10 +9,10 @@ Visit [this](https://docs.dapr.io/developing-applications/building-blocks/state-
 ## Pre-requisites
 
 * [Dapr and Dapr Cli](https://docs.dapr.io/getting-started/install-dapr-cli/).
-* Java JDK 11 (or greater):
-  * [Microsoft JDK 11](https://docs.microsoft.com/en-us/java/openjdk/download#openjdk-11)
-  * [Oracle JDK 11](https://www.oracle.com/technetwork/java/javase/downloads/index.html#JDK11)
-  * [OpenJDK 11](https://jdk.java.net/11/)
+* Java JDK 17 (or greater):
+  * [Microsoft JDK 17](https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17)
+  * [Oracle JDK 17](https://www.oracle.com/java/technologies/downloads/?er=221886#java17)
+  * [OpenJDK 17](https://jdk.java.net/17/)
 * [Apache Maven](https://maven.apache.org/install.html) version 3.x.
 
 This quickstart includes one service: Java client service `order-processor`

--- a/state_management/java/sdk/order-processor/pom.xml
+++ b/state_management/java/sdk/order-processor/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <slf4jVersion>1.6.1</slf4jVersion>
+        <slf4jVersion>2.0.13</slf4jVersion>
     </properties>
     <dependencies>
         <dependency>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.32</version>
             <optional>true</optional>
         </dependency>
     </dependencies>
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.3</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/workflows/java/sdk/order-processor/pom.xml
+++ b/workflows/java/sdk/order-processor/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <slf4jVersion>1.6.1</slf4jVersion>
+        <slf4jVersion>2.0.13</slf4jVersion>
     </properties>
     <dependencies>
         <dependency>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.13</version>
         </dependency>
     </dependencies>
 
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.6.3</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
feat: bumped up dependencies for Java Quickstarts , Springboot 2 is out of support so i have changes all the projects to use latest springboot 3 version available on the day of raising PR. I have tested all projects locally and github actions as well.
docs: Updated read me files to use Java 17 as baseline
Signed-off-by: amardeep2006 <amardeep2006@gmail.com>

# Description

_Please explain the changes you've made_
Upgraded Java Quickstarts to latest versions of dependencies.
## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_
https://github.com/dapr/quickstarts/issues/1042
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
