### PR TITLE
Fixes Python test failure on Configuration API quickstart

### DIFF
--- a/configuration/python/sdk/README.md
+++ b/configuration/python/sdk/README.md
@@ -47,7 +47,7 @@ pip3 install -r requirements.txt
 <!-- STEP
 name: Run order-processor service
 expected_stdout_lines:
-  - '== APP == Configuration for orderId2 : value: "102"'
+  - '== APP == Configuration for orderId2 : 102'
   - '== APP == Subscription ID is'
 expected_stderr_lines:
 output_match_mode: substring

--- a/configuration/python/sdk/order-processor/app.py
+++ b/configuration/python/sdk/order-processor/app.py
@@ -15,11 +15,11 @@ with DaprClient() as client:
     # Get config items from the config store
     for key in CONFIGURATION_KEYS:
         resp = client.get_configuration(store_name=DAPR_CONFIGURATION_STORE, keys=[key], config_metadata={})
-        print(f"Configuration for {key} : {resp.items[key]}", flush=True)
+        print(f"Configuration for {key} : {resp.items[key].value}", flush=True)
 
 def handler(id: str, resp: ConfigurationResponse):
     for key in resp.items:
-        print("Configuration update {'"+key+"' : {'value': '"+ resp.items[key].value +"'}}", flush=True)
+        print(f"Configuration update {key} : {resp.items[key].value}", flush=True)
 
 
 async def subscribe_config():
@@ -38,6 +38,3 @@ async def subscribe_config():
             print("Error unsubscribing from config updates", flush=True)
 
 asyncio.run(subscribe_config())
-
-
-


### PR DESCRIPTION
Test failures can happen running tests on 1.13 -> 1.14 because test relied on implicit ToString instead of inspecting .value off of the configuration item.  Also ensure print consistently handles string interpolation.  

Thank you @berndverst for educating me here.

## Issue reference
#1050 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
