### PR TITLE
InvariantCulture to fix localization

### DIFF
--- a/bindings/csharp/http/batch/program.cs
+++ b/bindings/csharp/http/batch/program.cs
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
-using System.Globalization;
 
 //dapr run --app-id batch-http --app-port 7001 --resources-path ../../../components -- dotnet run
 

--- a/bindings/csharp/http/batch/program.cs
+++ b/bindings/csharp/http/batch/program.cs
@@ -10,13 +10,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-using System;
+
+using Microsoft.AspNetCore.Localization;
 using System.Globalization;
-using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.AspNetCore.Mvc;
 
 //dapr run --app-id batch-http --app-port 7001 --resources-path ../../../components -- dotnet run
 
@@ -28,9 +27,19 @@ var daprPort = Environment.GetEnvironmentVariable("DAPR_HTTP_PORT") ?? "3500";
 var daprUrl = $"{baseURL}:{daprPort}/v1.0/bindings/{sqlBindingName}";
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<RequestLocalizationOptions>(options =>
+{
+     var invariantCulture = CultureInfo.InvariantCulture;
+     options.DefaultRequestCulture = new RequestCulture(invariantCulture);
+     options.SupportedCultures = [invariantCulture];
+});
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment()) { app.UseDeveloperExceptionPage(); }
+
+app.UseRequestLocalization();
 
 var httpClient = new HttpClient();
 httpClient.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
@@ -39,9 +48,6 @@ httpClient.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTyp
 app.MapPost("/" + cronBindingName, async () =>
 {
      Console.WriteLine("Processing batch..");
-
-     // Ensure the culture is set to one that uses dot notation
-     CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 
      string jsonFile = File.ReadAllText("../../../orders.json");
      var ordersArray = JsonSerializer.Deserialize<Orders>(jsonFile);

--- a/bindings/csharp/sdk/batch/program.cs
+++ b/bindings/csharp/sdk/batch/program.cs
@@ -10,13 +10,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-using System;
+
+using Microsoft.AspNetCore.Localization;
 using System.Globalization;
-using System.IO;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.AspNetCore.Mvc;
 using Dapr.Client;
 
 // dapr run --app-id batch-sdk --app-port 7002 --resources-path ../../../components -- dotnet run
@@ -25,17 +23,24 @@ var cronBindingName = "cron";
 var sqlBindingName = "sqldb";
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<RequestLocalizationOptions>(options =>
+{
+    var invariantCulture = CultureInfo.InvariantCulture;
+    options.DefaultRequestCulture = new RequestCulture(invariantCulture);
+    options.SupportedCultures = [invariantCulture];
+});
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment()) { app.UseDeveloperExceptionPage(); }
+
+app.UseRequestLocalization();
 
 // Triggered by Dapr input binding
 app.MapPost("/" + cronBindingName, async () =>
 {
     Console.WriteLine("Processing batch..");
-
-    // Ensure the culture is set to one that uses dot notation
-    CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 
     string jsonFile = File.ReadAllText("../../../orders.json");
     var ordersArray = JsonSerializer.Deserialize<Orders>(jsonFile);

--- a/bindings/csharp/sdk/batch/program.cs
+++ b/bindings/csharp/sdk/batch/program.cs
@@ -11,13 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Dapr.Client;
-using System.Globalization;
 
 // dapr run --app-id batch-sdk --app-port 7002 --resources-path ../../../components -- dotnet run
 

--- a/bindings/csharp/sdk/batch/program.cs
+++ b/bindings/csharp/sdk/batch/program.cs
@@ -17,7 +17,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Dapr.Client;
-
+using System.Globalization;
 
 // dapr run --app-id batch-sdk --app-port 7002 --resources-path ../../../components -- dotnet run
 
@@ -27,18 +27,23 @@ var sqlBindingName = "sqldb";
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment()) {app.UseDeveloperExceptionPage();}
+if (app.Environment.IsDevelopment()) { app.UseDeveloperExceptionPage(); }
 
 // Triggered by Dapr input binding
-app.MapPost("/" + cronBindingName, async () => {
-
+app.MapPost("/" + cronBindingName, async () =>
+{
     Console.WriteLine("Processing batch..");
+
+    // Ensure the culture is set to one that uses dot notation
+    CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
     string jsonFile = File.ReadAllText("../../../orders.json");
     var ordersArray = JsonSerializer.Deserialize<Orders>(jsonFile);
     using var client = new DaprClientBuilder().Build();
-    foreach(Order ord in ordersArray?.orders ?? new Order[] {}){
+    foreach (Order ord in ordersArray?.orders ?? new Order[] { })
+    {
         var sqlText = $"insert into orders (orderid, customer, price) values ({ord.OrderId}, '{ord.Customer}', {ord.Price});";
-        var command = new Dictionary<string,string>(){
+        var command = new Dictionary<string, string>(){
             {"sql",
             sqlText}
         };


### PR DESCRIPTION
# Description

Use `InvariantCulture` to fix localization.

Or else you get (on non-US): 

```
== APP == insert into orders (orderid, customer, price) values (1, 'John Smith', 100,32);
== APP == fail: Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware[1]
== APP ==       An unhandled exception has occurred while executing the request.
== APP ==       Dapr.DaprException: Binding operation failed: the Dapr endpoint indicated a failure. See InnerException for details.
== APP ==        ---> Grpc.Core.RpcException: Status(StatusCode="Internal", Detail="error invoking output binding sqldb: error executing query: ERROR: INSERT has more expressions than target columns (SQLSTATE 42601)")`
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
