### PR TITLE
Fix distributed calculator tutorial Go docker build

### DIFF
--- a/tutorials/distributed-calculator/go/Dockerfile
+++ b/tutorials/distributed-calculator/go/Dockerfile
@@ -1,8 +1,7 @@
 #first stage - builder
-FROM golang:1.15-buster as builder
+FROM golang:1.19-buster as builder
 WORKDIR /dir
-COPY app.go .
-RUN go get -d -v
+COPY app.go go.mod go.sum ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 #second stage
 FROM debian:buster-slim

--- a/tutorials/distributed-calculator/go/Dockerfile
+++ b/tutorials/distributed-calculator/go/Dockerfile
@@ -1,10 +1,10 @@
 #first stage - builder
-FROM golang:1.19-buster as builder
+FROM golang:1.22-bookworm as builder
 WORKDIR /dir
 COPY app.go go.mod go.sum ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 #second stage
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 WORKDIR /root/
 COPY --from=builder /dir/app .
 CMD ["./app"]


### PR DESCRIPTION
# Description

Go example was using old Go image (1.15) for newer Go in `go.mod` 1.19.
Updated the image version and included `go.mod` and `go.sum`

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
