### PR TITLE
Updating dockerfiles used in Tutorial make build (C#,Python,Node,ReactClient)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Debug/
 .settings/
 .metadata
 .project
+out/
 
 # Package Files #
 *.jar

--- a/tutorials/distributed-calculator/csharp/Dockerfile
+++ b/tutorials/distributed-calculator/csharp/Dockerfile
@@ -16,8 +16,5 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
 
-# Expose the port the application runs on
-EXPOSE 80
-
 # Run the application
-ENTRYPOINT ["dotnet", "YourProjectName.dll"]
+ENTRYPOINT ["dotnet", "Subtract.dll"]

--- a/tutorials/distributed-calculator/csharp/Dockerfile
+++ b/tutorials/distributed-calculator/csharp/Dockerfile
@@ -1,7 +1,23 @@
-# Note: we cannot do a staged dotnet docker build here for arm/arm64. 
-
-# Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+# Use the official .NET 7 SDK image to build the application
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /app
-COPY  /out .
-ENTRYPOINT ["dotnet", "Subtract.dll"]
+
+# Copy the project file and restore dependencies
+COPY *.csproj ./
+RUN dotnet clean
+RUN dotnet restore --disable-parallel
+
+# Copy the rest of the application code and build the application
+COPY . ./
+RUN dotnet publish -c Release -o out
+
+# Use the official .NET 7 runtime image to run the application
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/out .
+
+# Expose the port the application runs on
+EXPOSE 80
+
+# Run the application
+ENTRYPOINT ["dotnet", "YourProjectName.dll"]

--- a/tutorials/distributed-calculator/node/Dockerfile
+++ b/tutorials/distributed-calculator/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install

--- a/tutorials/distributed-calculator/python/Dockerfile
+++ b/tutorials/distributed-calculator/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 COPY . /app
 WORKDIR /app
 RUN pip install flask flask_cors

--- a/tutorials/distributed-calculator/react-calculator/Dockerfile
+++ b/tutorials/distributed-calculator/react-calculator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install

--- a/tutorials/hello-kubernetes/node/Dockerfile
+++ b/tutorials/hello-kubernetes/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /app
 COPY . .
 RUN npm install

--- a/tutorials/hello-kubernetes/python/Dockerfile
+++ b/tutorials/hello-kubernetes/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 WORKDIR /app
 COPY . . 
 RUN pip install requests

--- a/tutorials/observability/python/Dockerfile
+++ b/tutorials/observability/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 COPY . /app
 WORKDIR /app
 RUN pip install flask flask_cors

--- a/tutorials/pub-sub/csharp-subscriber/Dockerfile
+++ b/tutorials/pub-sub/csharp-subscriber/Dockerfile
@@ -1,6 +1,22 @@
-# Note: we cannot do a staged dotnet docker build here for arm/arm64. 
-
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+# Use the official .NET 8 SDK image to build the application
+FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
-COPY  /out .
+
+# Copy the project file and restore dependencies
+COPY *.csproj ./
+RUN dotnet restore --disable-parallel
+
+# Copy the rest of the application code and build the application
+COPY . ./
+RUN dotnet publish -c Release -o out
+
+# Use the official .NET 8 runtime image to run the application
+FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/out .
+
+# Expose the port the application runs on
+EXPOSE 80
+
+# Run the application
 ENTRYPOINT ["dotnet", "csharp-subscriber.dll"]

--- a/tutorials/pub-sub/node-subscriber/Dockerfile
+++ b/tutorials/pub-sub/node-subscriber/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install

--- a/tutorials/pub-sub/python-subscriber/Dockerfile
+++ b/tutorials/pub-sub/python-subscriber/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 COPY . /app
 WORKDIR /app
 RUN pip install flask flask_cors

--- a/tutorials/pub-sub/react-form/Dockerfile
+++ b/tutorials/pub-sub/react-form/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm run build


### PR DESCRIPTION
# Description

Updating tools chains in dockerfiles to:
- use latest of each language stack's SDK that is compatible with app
- multi stage build in .net for performance and size
- build and test clean with `make build` in each tutorial folder
- leveraged by build.yaml github action workflow

## Issue reference

This is a companion fix to #1058 for the other languages
