### PR TITLE
Tutorial dockerfile fix for multi-arch build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Debug/
 .settings/
 .metadata
 .project
+out/
 
 # Package Files #
 *.jar

--- a/tutorials/distributed-calculator/csharp/Dockerfile
+++ b/tutorials/distributed-calculator/csharp/Dockerfile
@@ -16,8 +16,5 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
 
-# Expose the port the application runs on
-EXPOSE 80
-
 # Run the application
-ENTRYPOINT ["dotnet", "YourProjectName.dll"]
+ENTRYPOINT ["dotnet", "Subtract.dll"]

--- a/tutorials/distributed-calculator/csharp/Dockerfile
+++ b/tutorials/distributed-calculator/csharp/Dockerfile
@@ -1,7 +1,23 @@
-# Note: we cannot do a staged dotnet docker build here for arm/arm64. 
-
-# Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+# Use the official .NET 7 SDK image to build the application
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /app
-COPY  /out .
-ENTRYPOINT ["dotnet", "Subtract.dll"]
+
+# Copy the project file and restore dependencies
+COPY *.csproj ./
+RUN dotnet clean
+RUN dotnet restore --disable-parallel
+
+# Copy the rest of the application code and build the application
+COPY . ./
+RUN dotnet publish -c Release -o out
+
+# Use the official .NET 7 runtime image to run the application
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/out .
+
+# Expose the port the application runs on
+EXPOSE 80
+
+# Run the application
+ENTRYPOINT ["dotnet", "YourProjectName.dll"]

--- a/tutorials/distributed-calculator/node/Dockerfile
+++ b/tutorials/distributed-calculator/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install

--- a/tutorials/distributed-calculator/python/Dockerfile
+++ b/tutorials/distributed-calculator/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 COPY . /app
 WORKDIR /app
 RUN pip install flask flask_cors

--- a/tutorials/distributed-calculator/react-calculator/Dockerfile
+++ b/tutorials/distributed-calculator/react-calculator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install

--- a/tutorials/hello-kubernetes/node/Dockerfile
+++ b/tutorials/hello-kubernetes/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /app
 COPY . .
 RUN npm install

--- a/tutorials/hello-kubernetes/python/Dockerfile
+++ b/tutorials/hello-kubernetes/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 WORKDIR /app
 COPY . . 
 RUN pip install requests

--- a/tutorials/observability/python/Dockerfile
+++ b/tutorials/observability/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 COPY . /app
 WORKDIR /app
 RUN pip install flask flask_cors

--- a/tutorials/pub-sub/csharp-subscriber/Dockerfile
+++ b/tutorials/pub-sub/csharp-subscriber/Dockerfile
@@ -1,6 +1,22 @@
-# Note: we cannot do a staged dotnet docker build here for arm/arm64. 
-
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+# Use the official .NET 8 SDK image to build the application
+FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
-COPY  /out .
+
+# Copy the project file and restore dependencies
+COPY *.csproj ./
+RUN dotnet restore --disable-parallel
+
+# Copy the rest of the application code and build the application
+COPY . ./
+RUN dotnet publish -c Release -o out
+
+# Use the official .NET 8 runtime image to run the application
+FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/out .
+
+# Expose the port the application runs on
+EXPOSE 80
+
+# Run the application
 ENTRYPOINT ["dotnet", "csharp-subscriber.dll"]

--- a/tutorials/pub-sub/csharp-subscriber/Dockerfile
+++ b/tutorials/pub-sub/csharp-subscriber/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official .NET 8 SDK image to build the application
-FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
 # Copy the project file and restore dependencies
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Use the official .NET 8 runtime image to run the application
-FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
 

--- a/tutorials/pub-sub/node-subscriber/Dockerfile
+++ b/tutorials/pub-sub/node-subscriber/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm install

--- a/tutorials/pub-sub/python-subscriber/Dockerfile
+++ b/tutorials/pub-sub/python-subscriber/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 COPY . /app
 WORKDIR /app
 RUN pip install flask flask_cors

--- a/tutorials/pub-sub/react-form/Dockerfile
+++ b/tutorials/pub-sub/react-form/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/app
 COPY . .
 RUN npm run build


### PR DESCRIPTION
# Description

The current pubsub C# dockerfile had multi arch (platform) flag in place but it was hard coded to arm64 matching my dev-test box.  This change makes the dockerfile truly multi-arch so it will build on our amd64 linux runners too.


## Issue reference

Fixes this test failure:
https://github.com/dapr/quickstarts/actions/runs/10081924109/job/27880177990#step:8:847

Tests and runs ok.

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
