### PR TITLE
Fixing dockerfile for Tutorial pubsub C# to be truly multi-arch

### DIFF
--- a/tutorials/pub-sub/csharp-subscriber/Dockerfile
+++ b/tutorials/pub-sub/csharp-subscriber/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official .NET 8 SDK image to build the application
-FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
 # Copy the project file and restore dependencies
@@ -11,7 +11,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Use the official .NET 8 runtime image to run the application
-FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
 


### PR DESCRIPTION
# Description

Fixing dockerfile for Tutorial pubsub C# to be truly multi-arch.  Was hard coded to arm64 (like apple silicon test machine)

## Issue reference

Fixes this test failure.
https://github.com/dapr/quickstarts/actions/runs/10081924109/job/27880177990#step:8:847

Tested and run in docker.

