### PR TITLE
fix: validate_tutorials

### DIFF
--- a/.github/workflows/validate_tutorials.yaml
+++ b/.github/workflows/validate_tutorials.yaml
@@ -136,7 +136,6 @@ jobs:
           helm repo update
           helm install redis bitnami/redis --version 17.14.5
           dapr init -k --dev --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --wait || kubectl get pods --all-namespaces
-          kubectl logs dapr-dev-redis-master-0 -n default
           kubectl get nodes -o wide
           for pod in `dapr status -k | awk '/dapr/ {print $1}'`; do kubectl describe pod -l app=$pod -n dapr-system ; kubectl logs -l app=$pod -n dapr-system; done
       - name: Install utilities dependencies

--- a/.github/workflows/validate_tutorials.yaml
+++ b/.github/workflows/validate_tutorials.yaml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     env:
-      GOVER: 1.17
-      KUBERNETES_VERSION: v1.21.1
-      KIND_VERSION: v0.12.0
-      KIND_IMAGE_SHA: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+      GOVER: 1.22
+      KUBERNETES_VERSION: v1.29.4
+      KIND_VERSION: v0.23.0
+      KIND_IMAGE_SHA: sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -136,6 +136,7 @@ jobs:
           helm repo update
           helm install redis bitnami/redis --version 17.14.5
           dapr init -k --dev --runtime-version=${{ env.DAPR_RUNTIME_VERSION }} --wait || kubectl get pods --all-namespaces
+          kubectl logs dapr-dev-redis-master-0 -n default
           kubectl get nodes -o wide
           for pod in `dapr status -k | awk '/dapr/ {print $1}'`; do kubectl describe pod -l app=$pod -n dapr-system ; kubectl logs -l app=$pod -n dapr-system; done
       - name: Install utilities dependencies

--- a/tutorials/hello-kubernetes/README.md
+++ b/tutorials/hello-kubernetes/README.md
@@ -272,7 +272,7 @@ To call the service that you set up port forwarding to, from a command prompt ru
 <!-- STEP
 name: Curl Test
 expected_stdout_lines:
-  - '{"DAPR_HTTP_PORT":"3500","DAPR_GRPC_PORT":"50001"}'
+  - '{"DAPR_HTTP_ENDPOINT":"http://localhost:3500","DAPR_GRPC_ENDPOINT":"http://localhost:50001"}'
 tags:
   - normal-run
 -->

--- a/tutorials/hello-kubernetes/dapr.yaml
+++ b/tutorials/hello-kubernetes/dapr.yaml
@@ -1,4 +1,6 @@
 version: 1
+common:
+  resourcesPath: ./resources
 apps:
   - appDirPath: ./node
     appID: nodeapp

--- a/tutorials/hello-kubernetes/resources/resiliency.yaml
+++ b/tutorials/hello-kubernetes/resources/resiliency.yaml
@@ -1,0 +1,8 @@
+spec:
+  policies:
+    retries:
+      # Global Retry Policy
+      DefaultRetryPolicy:
+        policy: constant
+        duration: 1s
+        maxRetries: -1

--- a/tutorials/observability/README.md
+++ b/tutorials/observability/README.md
@@ -389,6 +389,8 @@ expected_stdout_lines:
   - '"total":"54"'
 output_match_mode: substring
 name: "Curl test"
+background: false
+sleep: 5
 -->
 
 ```bash
@@ -476,6 +478,7 @@ output_match_mode: substring
 expected_stderr_lines:
 
 name: Curl validate
+background: false
 -->
 
 ```bash


### PR DESCRIPTION
# Description

- Renames the tutorials validation workflow to `validate_tutorials.yaml`
- Bumps kind & kubernetes to more recent, supported versions and image tag.
- Defines a global resiliency policy
- Updates dapr returned endpoints
- Adds some timings to allow for metrics to propagate before validation takes place

## Issue reference

CLI related issue: [1436](https://github.com/dapr/cli/issues/1436)

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
