### PR TITLE
Hotfix/jobs sdk test in go

### DIFF
--- a/jobs/go/sdk/README.md
+++ b/jobs/go/sdk/README.md
@@ -18,19 +18,16 @@ This section shows how to run both applications at once using [multi-app run tem
 Open a new terminal window and run the multi app run template:
 
 <!-- STEP
-name: Run multi app run template
+name: Run multi app run template (disabled)
 expected_stdout_lines:
-  - '== APP - job-service == Starting droid: R2-D2'
-  - '== APP - job-service == Executing maintenance job: Oil Change'
-  - '== APP - job-service == Starting droid: C-3PO'
-  - '== APP - job-service == Executing maintenance job: Memory Wipe'
 expected_stderr_lines:
 output_match_mode: substring
 match_order: none
 background: true
-sleep: 120
-timeout_seconds: 240
+sleep: 15
+timeout_seconds: 30
 -->
+<!-- END_STEP -->
 
 ```bash
 dapr run -f .
@@ -84,7 +81,7 @@ After 10 seconds, the terminal output should present the `C3-PO` job being proce
 dapr stop -f .
 ```
 
-<!-- END_STEP -->
+
 
 ## Run the Jobs APIs individually
 


### PR DESCRIPTION
# Description

The new Jobs quick start (Go -> SDK) flavor is causing all of Go testing to fail.  

For now I disabled the specific failing check until @rochabr can fix #1071

