### PR TITLE
Fix for Quickstart Failure

### DIFF
--- a/configuration/javascript/sdk/order-processor/package-lock.json
+++ b/configuration/javascript/sdk/order-processor/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@dapr/dapr": "^3.3.0"
+                "@dapr/dapr": "^3.3.1"
             },
             "devDependencies": {
                 "eslint": "^8.8.0",
@@ -17,9 +17,10 @@
             }
         },
         "node_modules/@dapr/dapr": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.3.0.tgz",
-            "integrity": "sha512-Q12a04HnldEaG7ts4ZWeCV9FChi1tDHPHxLdDawvs21oC48mVFQZGOo/F165CFdpcD/ZValGWgqDbR3aPBtZbA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.3.1.tgz",
+            "integrity": "sha512-rQwN1Ionetna6y36buYkxMX1i4Vy8w+Ni8edpJRLUKwLPA22XwjuVw+UXGfBZkWGG1ggaqCty2x87lQLe8ZYzw==",
+            "license": "ISC",
             "dependencies": {
                 "@grpc/grpc-js": "^1.9.3",
                 "@js-temporal/polyfill": "^0.3.0",
@@ -2943,9 +2944,9 @@
     },
     "dependencies": {
         "@dapr/dapr": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.3.0.tgz",
-            "integrity": "sha512-Q12a04HnldEaG7ts4ZWeCV9FChi1tDHPHxLdDawvs21oC48mVFQZGOo/F165CFdpcD/ZValGWgqDbR3aPBtZbA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.3.1.tgz",
+            "integrity": "sha512-rQwN1Ionetna6y36buYkxMX1i4Vy8w+Ni8edpJRLUKwLPA22XwjuVw+UXGfBZkWGG1ggaqCty2x87lQLe8ZYzw==",
             "requires": {
                 "@grpc/grpc-js": "^1.9.3",
                 "@js-temporal/polyfill": "^0.3.0",

--- a/configuration/javascript/sdk/order-processor/package.json
+++ b/configuration/javascript/sdk/order-processor/package.json
@@ -15,6 +15,6 @@
         "eslint-plugin-react": "^7.28.0"
     },
     "dependencies": {
-        "@dapr/dapr": "^3.3.0"
+        "@dapr/dapr": "^3.3.1"
     }
 }

--- a/cryptography/javascript/sdk/crypto-quickstart/package-lock.json
+++ b/cryptography/javascript/sdk/crypto-quickstart/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@dapr/dapr": "^3.3.0"
+                "@dapr/dapr": "^3.3.1"
             },
             "devDependencies": {
                 "@types/node": "^18.0.0",
@@ -17,9 +17,10 @@
             }
         },
         "node_modules/@dapr/dapr": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.3.0.tgz",
-            "integrity": "sha512-Q12a04HnldEaG7ts4ZWeCV9FChi1tDHPHxLdDawvs21oC48mVFQZGOo/F165CFdpcD/ZValGWgqDbR3aPBtZbA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.3.1.tgz",
+            "integrity": "sha512-rQwN1Ionetna6y36buYkxMX1i4Vy8w+Ni8edpJRLUKwLPA22XwjuVw+UXGfBZkWGG1ggaqCty2x87lQLe8ZYzw==",
+            "license": "ISC",
             "dependencies": {
                 "@grpc/grpc-js": "^1.9.3",
                 "@js-temporal/polyfill": "^0.3.0",
@@ -2276,9 +2277,9 @@
     },
     "dependencies": {
         "@dapr/dapr": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.3.0.tgz",
-            "integrity": "sha512-Q12a04HnldEaG7ts4ZWeCV9FChi1tDHPHxLdDawvs21oC48mVFQZGOo/F165CFdpcD/ZValGWgqDbR3aPBtZbA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@dapr/dapr/-/dapr-3.3.1.tgz",
+            "integrity": "sha512-rQwN1Ionetna6y36buYkxMX1i4Vy8w+Ni8edpJRLUKwLPA22XwjuVw+UXGfBZkWGG1ggaqCty2x87lQLe8ZYzw==",
             "requires": {
                 "@grpc/grpc-js": "^1.9.3",
                 "@js-temporal/polyfill": "^0.3.0",

--- a/cryptography/javascript/sdk/crypto-quickstart/package.json
+++ b/cryptography/javascript/sdk/crypto-quickstart/package.json
@@ -12,7 +12,7 @@
     "author": "",
     "license": "MIT",
     "dependencies": {
-        "@dapr/dapr": "^3.3.0"
+        "@dapr/dapr": "^3.3.1"
     },
     "devDependencies": {
         "@types/node": "^18.0.0",


### PR DESCRIPTION
# Description

I debugged and found that the issue happened as, in isStarted func of sidecar.js, we are using GetMetadata API which had an Empty proto as request, while that was updated and wrapped inside a GetMetadataRequest().
But, I also found that it is already being used by v3.3.1 - so referred that and issue got resolved.

refer this run for validation: https://github.com/DeepanshuA/quickstarts/actions/runs/10109780799/job/27958376419

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1047 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
