### PR TITLE
Fix workflows to use `docker compose` instead of `docker-compose`

### DIFF
--- a/bindings/csharp/http/README.md
+++ b/bindings/csharp/http/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/csharp/sdk/README.md
+++ b/bindings/csharp/sdk/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/go/http/README.md
+++ b/bindings/go/http/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/go/sdk/README.md
+++ b/bindings/go/sdk/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/java/http/README.md
+++ b/bindings/java/http/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/java/sdk/README.md
+++ b/bindings/java/sdk/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/javascript/http/README.md
+++ b/bindings/javascript/http/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/javascript/sdk/README.md
+++ b/bindings/javascript/sdk/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/python/http/README.md
+++ b/bindings/python/http/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/bindings/python/sdk/README.md
+++ b/bindings/python/sdk/README.md
@@ -24,7 +24,7 @@ timeout_seconds: 120
 
 ```bash
 cd ../../db
-docker-compose up
+docker compose up
 ```
 
 <!-- END_STEP -->

--- a/tutorials/bindings/README.md
+++ b/tutorials/bindings/README.md
@@ -49,7 +49,7 @@ sleep: 20
 -->
 
 ```bash
-docker-compose -f ./docker-compose-single-kafka.yml up -d
+docker compose -f ./docker-compose-single-kafka.yml up -d
 ```
 
 2. To see the container running locally, run:
@@ -217,7 +217,7 @@ dapr stop --app-id bindings-pythonapp
 Once you're done, you can spin down your local Kafka Docker Container by running:
 
 ```bash
-docker-compose -f ./docker-compose-single-kafka.yml down
+docker compose -f ./docker-compose-single-kafka.yml down
 ```
 
 <!-- END_STEP -->


### PR DESCRIPTION
# Description

Fix workflows to use `docker compose` instead of `docker-compose`

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: n/a

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
