### PR TITLE
fix: Jobs go/sdk event data payload

### DIFF
--- a/jobs/go/sdk/job-service/job-service.go
+++ b/jobs/go/sdk/job-service/job-service.go
@@ -19,7 +19,6 @@ dapr run --app-id maintenance-scheduler --app-port 5200 --dapr-http-port 5280 --
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -201,16 +200,8 @@ func deleteJob(ctx context.Context, in *common.InvocationEvent) (out *common.Con
 
 // Handler that handles job events
 func handleJob(ctx context.Context, job *common.JobEvent) error {
-	var jobData common.Job
-	if err := json.Unmarshal(job.Data, &jobData); err != nil {
-		return fmt.Errorf("failed to unmarshal job: %v", err)
-	}
-	decodedPayload, err := base64.StdEncoding.DecodeString(jobData.Value)
-	if err != nil {
-		return fmt.Errorf("failed to decode job payload: %v", err)
-	}
 	var jobPayload JobData
-	if err := json.Unmarshal(decodedPayload, &jobPayload); err != nil {
+	if err := json.Unmarshal(job.Data, &jobPayload); err != nil {
 		return fmt.Errorf("failed to unmarshal payload: %v", err)
 	}
 


### PR DESCRIPTION
# Description

Small fix in how `JobEvent` data is handled - `Data` now contains the job payload as opposed to the spec (as per original example).

## Issue reference

Closes #1095

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
