### PR TITLE
refactor: update python workflow example with daprWorkflowClient

### DIFF
--- a/workflows/python/sdk/README.md
+++ b/workflows/python/sdk/README.md
@@ -34,7 +34,7 @@ cd ..
 name: Running this example
 expected_stdout_lines:
   - "There are now 90 cars left in stock"
-  - "Workflow completed! Result: Completed"
+  - "Workflow completed!"
 output_match_mode: substring
 background: true
 timeout_seconds: 120


### PR DESCRIPTION
# Description

Notice the python quickstart example is outdated, so update it to use `DaprWorkflowClient` instead of `DaprClient`, same as here in python-sdk repo https://github.com/dapr/python-sdk/blob/main/examples/workflow/child_workflow.py

Checked mm.py and verify it works
<img width="712"  src="https://github.com/user-attachments/assets/1b2ae9f7-832e-491d-82e5-581ab05da891">

## Issue reference

https://github.com/dapr/quickstarts/issues/1119

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
