### PR TITLE
helloworld: add terminal to node app for vscode

### DIFF
--- a/tutorials/hello-world/.vscode/launch.json
+++ b/tutorials/hello-world/.vscode/launch.json
@@ -13,7 +13,8 @@
             ],
             "program": "${workspaceFolder}/node/app.js",
             "preLaunchTask": "daprd-debug-node",
-            "postDebugTask": "daprd-down-node"
+            "postDebugTask": "daprd-down-node",
+            "console": "integratedTerminal"
         },
         {
             "type": "python",


### PR DESCRIPTION
# Description

When trying to debug helloworld app in vscode I noticed there is no terminal for node app which makes debugging not easy. This PR fixes this issue

## Issue reference

#1124 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
