### PR TITLE
Update Dapr Actors Quickstart - .NET

### DIFF
--- a/actors/csharp/sdk/README.md
+++ b/actors/csharp/sdk/README.md
@@ -13,7 +13,7 @@ Let's take a look at the Dapr [Actors building block](https://docs.dapr.io/devel
 For this example, you will need:
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started).
-- [.NET 7 SDK](https://dotnet.microsoft.com/download).
+- [.NET 8 SDK](https://dotnet.microsoft.com/download).
 - Docker Desktop
 
 ### Step 2: Set up the environment

--- a/actors/csharp/sdk/client/SmartDevice.Client.csproj
+++ b/actors/csharp/sdk/client/SmartDevice.Client.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Actors" Version="1.14.*-*" />
+    <PackageReference Include="Dapr.Actors" Version="1.15.0-rc02" />
   </ItemGroup>
 
   <ItemGroup>

--- a/actors/csharp/sdk/service/SmartDevice.Service.csproj
+++ b/actors/csharp/sdk/service/SmartDevice.Service.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Actors" Version="1.14.*-*" />
-    <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.14.*-*" />
+    <PackageReference Include="Dapr.Actors" Version="1.15.0-rc02" />
+    <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.15.0-rc02" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

.NET 7 is **NOT** a supported target. Updated the README and updated the Dapr packages to 1.15.0-rc02.

## Issue reference

N/A - part of [1.15 endgame](https://github.com/dapr/dapr/issues/8313)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
* [X] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
