### PR TITLE
Quickstart bindings dotnet

### DIFF
--- a/bindings/csharp/sdk/batch/batch.csproj
+++ b/bindings/csharp/sdk/batch/batch.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
   
     <ItemGroup>
-      <PackageReference Include="Dapr.AspNetCore" Version="1.14.*-*" />
+      <PackageReference Include="Dapr.AspNetCore" Version="1.15.0-rc02" />
     </ItemGroup>
 
   </Project>

--- a/bindings/csharp/sdk/batch/program.cs
+++ b/bindings/csharp/sdk/batch/program.cs
@@ -67,4 +67,4 @@ app.MapPost("/" + cronBindingName, async (DaprClient client) =>
 await app.RunAsync();
 
 public sealed record Order([property: JsonPropertyName("orderid")] int OrderId, [property: JsonPropertyName("customer")] string Customer, [property: JsonPropertyName("price")] float Price);
-public saeled record Orders([property: JsonPropertyName("orders")] Order[] orders);
+public sealed record Orders([property: JsonPropertyName("orders")] Order[] orders);

--- a/bindings/csharp/sdk/batch/program.cs
+++ b/bindings/csharp/sdk/batch/program.cs
@@ -31,6 +31,8 @@ builder.Services.Configure<RequestLocalizationOptions>(options =>
     options.SupportedCultures = [invariantCulture];
 });
 
+builder.Services.AddDaprClient();
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment()) { app.UseDeveloperExceptionPage(); }
@@ -38,13 +40,12 @@ if (app.Environment.IsDevelopment()) { app.UseDeveloperExceptionPage(); }
 app.UseRequestLocalization();
 
 // Triggered by Dapr input binding
-app.MapPost("/" + cronBindingName, async () =>
+app.MapPost("/" + cronBindingName, async (DaprClient client) =>
 {
     Console.WriteLine("Processing batch..");
 
     string jsonFile = File.ReadAllText("../../../orders.json");
     var ordersArray = JsonSerializer.Deserialize<Orders>(jsonFile);
-    using var client = new DaprClientBuilder().Build();
     foreach (Order ord in ordersArray?.orders ?? new Order[] { })
     {
         var sqlText = $"insert into orders (orderid, customer, price) values ({ord.OrderId}, '{ord.Customer}', {ord.Price});";
@@ -65,5 +66,5 @@ app.MapPost("/" + cronBindingName, async () =>
 
 await app.RunAsync();
 
-public record Order([property: JsonPropertyName("orderid")] int OrderId, [property: JsonPropertyName("customer")] string Customer, [property: JsonPropertyName("price")] float Price);
-public record Orders([property: JsonPropertyName("orders")] Order[] orders);
+public sealed record Order([property: JsonPropertyName("orderid")] int OrderId, [property: JsonPropertyName("customer")] string Customer, [property: JsonPropertyName("price")] float Price);
+public saeled record Orders([property: JsonPropertyName("orders")] Order[] orders);


### PR DESCRIPTION
# Description

Dapr package version bump to 1.15.0-rc02. Tweaked program to favor DI registration over the static client builder.

## Issue reference

N/A - part of [1.15 endgame](https://github.com/dapr/dapr/issues/8313)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
* [X] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
