### PR TITLE
Conversation JS HTTP Quickstart

### DIFF
--- a/conversation/javascript/http/README.md
+++ b/conversation/javascript/http/README.md
@@ -1,0 +1,99 @@
+# Dapr Conversation API (Go HTTP)
+
+In this quickstart, you'll send an input to a mock Large Language Model (LLM) using Dapr's Conversation API. This API is responsible for providing one consistent API entry point to talk to underlying LLM providers.
+
+Visit [this](https://v1-15.docs.dapr.io/developing-applications/building-blocks/conversation/conversation-overview/) link for more information about Dapr and the Conversation API.
+
+> **Note:** This example leverages HTTP `requests` only.
+
+This quickstart includes one app:
+
+- `conversation.js`, responsible for sending an input to the underlying LLM and retrieving an output.
+
+## Run the app with the template file
+
+This section shows how to run the application using the [multi-app run template files](https://docs.dapr.io/developing-applications/local-development/multi-app-dapr-run/multi-app-overview/) with `dapr run -f .`.
+
+This example uses the default LLM Component provided by Dapr which simply echoes the input provided, for testing purposes. Here are other [supported Conversation components](https://v1-15.docs.dapr.io/reference/components-reference/supported-conversation/).
+
+1. Install dependencies:
+
+<!-- STEP
+name: Install Node dependencies for conversation
+-->
+
+```bash
+cd ./conversation
+npm install
+```
+
+<!-- END_STEP -->
+
+2. Open a new terminal window and run the multi app run template:
+
+<!-- STEP
+name: Run multi app run template
+expected_stdout_lines:
+  - '== APP - conversation == Input sent: What is dapr?'
+  - '== APP - conversation == Output response: What is dapr?'
+expected_stderr_lines:
+output_match_mode: substring
+match_order: none
+background: true
+sleep: 15
+timeout_seconds: 30
+-->
+
+```bash
+dapr run -f .
+```
+
+The terminal console output should look similar to this, where:
+
+- The app sends an input `What is dapr?` to the `echo` Component mock LLM.
+- The mock LLM echoes `What is dapr?`.
+
+```text
+== APP - conversation == Input sent: What is dapr?
+== APP - conversation == Output response: What is dapr?
+```
+
+<!-- END_STEP -->
+
+3. Stop and clean up application processes.
+
+<!-- STEP
+name: Stop multi-app run
+sleep: 5
+-->
+
+```bash
+dapr stop -f .
+```
+
+<!-- END_STEP -->
+
+## Run the app individually
+
+1. Open a terminal and run the `conversation` app. Build the dependencies if you haven't already.
+
+```bash
+cd ./conversation
+npm install
+```
+
+2. Run the Dapr process alongside the application.
+
+```bash
+dapr run --app-id conversation --resources-path ../../../components/ -- npm run start
+```
+
+The terminal console output should look similar to this, where:
+
+- The app sends an input `What is dapr?` to the `echo` Component mock LLM.
+- The mock LLM echoes `What is dapr?`.
+
+```text
+== APP - conversation == Input sent: What is dapr?
+== APP - conversation == Output response: What is dapr?
+```

--- a/conversation/javascript/http/README.md
+++ b/conversation/javascript/http/README.md
@@ -8,7 +8,7 @@ Visit [this](https://v1-15.docs.dapr.io/developing-applications/building-blocks/
 
 This quickstart includes one app:
 
-- `conversation.js`, responsible for sending an input to the underlying LLM and retrieving an output.
+- `index.js`, responsible for sending an input to the underlying LLM and retrieving an output.
 
 ## Run the app with the template file
 
@@ -75,7 +75,7 @@ dapr stop -f .
 
 ## Run the app individually
 
-1. Open a terminal and run the `conversation` app. Build the dependencies if you haven't already.
+1. Open a terminal and navigate to the `conversation` app. Install the dependencies if you haven't already.
 
 ```bash
 cd ./conversation

--- a/conversation/javascript/http/README.md
+++ b/conversation/javascript/http/README.md
@@ -1,4 +1,4 @@
-# Dapr Conversation API (Go HTTP)
+# Dapr Conversation API (JS HTTP)
 
 In this quickstart, you'll send an input to a mock Large Language Model (LLM) using Dapr's Conversation API. This API is responsible for providing one consistent API entry point to talk to underlying LLM providers.
 

--- a/conversation/javascript/http/conversation/index.js
+++ b/conversation/javascript/http/conversation/index.js
@@ -1,0 +1,43 @@
+const conversationComponentName = "echo";
+
+async function main() {
+  const daprHost = process.env.DAPR_HOST || "http://localhost";
+  const daprHttpPort = process.env.DAPR_HTTP_PORT || "3500";
+
+  const inputBody = {
+    name: "echo",
+    inputs: [{ message: "What is dapr?" }],
+    parameters: {},
+    metadata: {},
+  };
+
+  const reqURL = `${daprHost}:${daprHttpPort}/v1.0-alpha1/conversation/${conversationComponentName}/converse`;
+
+  try {
+    const response = await fetch(reqURL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(inputBody),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    console.log("Input sent: What is dapr?");
+
+    const data = await response.json();
+    const result = data.outputs[0].result;
+    console.log("Output response:", result);
+  } catch (error) {
+    console.error("Error:", error.message);
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error("Unhandled error:", error);
+  process.exit(1);
+});

--- a/conversation/javascript/http/conversation/index.js
+++ b/conversation/javascript/http/conversation/index.js
@@ -22,10 +22,6 @@ async function main() {
       body: JSON.stringify(inputBody),
     });
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
     console.log("Input sent: What is dapr?");
 
     const data = await response.json();

--- a/conversation/javascript/http/conversation/package-lock.json
+++ b/conversation/javascript/http/conversation/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "conversation",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "conversation",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/conversation/javascript/http/conversation/package.json
+++ b/conversation/javascript/http/conversation/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "conversation",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "start:dapr": "dapr run --app-id conversation --resources-path ../../../components/ -- npm start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/conversation/javascript/http/dapr.yaml
+++ b/conversation/javascript/http/dapr.yaml
@@ -1,0 +1,8 @@
+version: 1
+common:
+  resourcesPath: ../../components/
+apps:
+  - appDirPath: ./conversation/
+    appID: conversation
+    daprHTTPPort: 3502
+    command: ["npm", "run", "start"]

--- a/conversation/javascript/http/dapr.yaml
+++ b/conversation/javascript/http/dapr.yaml
@@ -2,7 +2,7 @@ version: 1
 common:
   resourcesPath: ../../components/
 apps:
-  - appDirPath: ./conversation/
-    appID: conversation
+  - appID: conversation
+    appDirPath: ./conversation/
     daprHTTPPort: 3502
     command: ["npm", "run", "start"]

--- a/conversation/javascript/http/makefile
+++ b/conversation/javascript/http/makefile
@@ -1,0 +1,2 @@
+include ../../../docker.mk
+include ../../../validate.mk


### PR DESCRIPTION
# Description

Added the missing quickstart for how to use the Dapr Conversation with Javascript through the standard HTTP `fetch`.

## Issue reference

https://github.com/dapr/quickstarts/issues/1107

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
* [X] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
