### PR TITLE
Jobs API Clarity: Rename schedulerDaprHttpPort -> jobServiceDaprHttpPort

### DIFF
--- a/jobs/csharp/http/job-scheduler/Program.cs
+++ b/jobs/csharp/http/job-scheduler/Program.cs
@@ -18,7 +18,7 @@ var r2d2JobBody = new
 };
 
 var daprHost = Environment.GetEnvironmentVariable("DAPR_HOST") ?? "http://localhost";
-var schedulerDaprHttpPort = "6280";
+var jobServiceDaprHttpPort = "6280";
 
 var httpClient = new HttpClient();
 
@@ -48,7 +48,7 @@ catch (Exception ex)
 
 async Task ScheduleJob(string jobName, object jobBody)
 {
-  var reqURL = $"{daprHost}:{schedulerDaprHttpPort}/v1.0-alpha1/jobs/{jobName}";
+  var reqURL = $"{daprHost}:{jobServiceDaprHttpPort}/v1.0-alpha1/jobs/{jobName}";
   var jsonBody = JsonSerializer.Serialize(jobBody);
   var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
@@ -64,7 +64,7 @@ async Task ScheduleJob(string jobName, object jobBody)
 
 async Task GetJobDetails(string jobName)
 {
-  var reqURL = $"{daprHost}:{schedulerDaprHttpPort}/v1.0-alpha1/jobs/{jobName}";
+  var reqURL = $"{daprHost}:{jobServiceDaprHttpPort}/v1.0-alpha1/jobs/{jobName}";
 
   var response = await httpClient.GetAsync(reqURL);
 

--- a/jobs/go/http/job-scheduler/job-scheduler.go
+++ b/jobs/go/http/job-scheduler/job-scheduler.go
@@ -35,7 +35,7 @@ func main() {
 		daprHost = "http://localhost"
 	}
 
-	schedulerDaprHttpPort := "6280"
+	jobServiceDaprHttpPort := "6280"
 
 	client := http.Client{
 		Timeout: 15 * time.Second,
@@ -43,7 +43,7 @@ func main() {
 
 	// Schedule a job using the Dapr Jobs API with short dueTime
 	jobName := "R2-D2"
-	reqURL := daprHost + ":" + schedulerDaprHttpPort + "/v1.0-alpha1/jobs/" + jobName
+	reqURL := daprHost + ":" + jobServiceDaprHttpPort + "/v1.0-alpha1/jobs/" + jobName
 
 	req, err := http.NewRequest("POST", reqURL, strings.NewReader(r2d2JobBody))
 	if err != nil {
@@ -71,7 +71,7 @@ func main() {
 	// Schedule a job using the Dapr Jobs API with long dueTime
 	jobName = "C-3PO"
 
-	reqURL = daprHost + ":" + schedulerDaprHttpPort + "/v1.0-alpha1/jobs/" + jobName
+	reqURL = daprHost + ":" + jobServiceDaprHttpPort + "/v1.0-alpha1/jobs/" + jobName
 
 	req, err = http.NewRequest("POST", reqURL, strings.NewReader(c3poJobBody))
 	if err != nil {
@@ -93,7 +93,7 @@ func main() {
 
 	// Gets a job using the Dapr Jobs API
 	jobName = "C-3PO"
-	reqURL = daprHost + ":" + schedulerDaprHttpPort + "/v1.0-alpha1/jobs/" + jobName
+	reqURL = daprHost + ":" + jobServiceDaprHttpPort + "/v1.0-alpha1/jobs/" + jobName
 
 	res, err = http.Get(reqURL)
 	if err != nil {

--- a/jobs/javascript/http/job-scheduler/index.js
+++ b/jobs/javascript/http/job-scheduler/index.js
@@ -13,7 +13,7 @@ const r2d2JobBody = {
   dueTime: "15s",
 };
 const daprHost = process.env.DAPR_HOST || "http://localhost";
-const schedulerDaprHttpPort = "6280";
+const jobServiceDaprHttpPort = "6280";
 
 async function main() {
   const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -45,7 +45,7 @@ async function main() {
 }
 
 async function scheduleJob(jobName, jobBody) {
-  const reqURL = `${daprHost}:${schedulerDaprHttpPort}/v1.0-alpha1/jobs/${jobName}`;
+  const reqURL = `${daprHost}:${jobServiceDaprHttpPort}/v1.0-alpha1/jobs/${jobName}`;
   const response = await fetch(reqURL, {
     method: "POST",
     headers: {
@@ -64,7 +64,7 @@ async function scheduleJob(jobName, jobBody) {
 }
 
 async function getJobDetails(jobName) {
-  const reqURL = `${daprHost}:${schedulerDaprHttpPort}/v1.0-alpha1/jobs/${jobName}`;
+  const reqURL = `${daprHost}:${jobServiceDaprHttpPort}/v1.0-alpha1/jobs/${jobName}`;
   const response = await fetch(reqURL, {
     method: "GET",
   });

--- a/jobs/python/http/README.md
+++ b/jobs/python/http/README.md
@@ -16,6 +16,11 @@ This quickstart includes two apps:
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 
+## Environment Variables
+
+- `JOB_SERVICE_DAPR_HTTP_PORT`: The Dapr HTTP port of the job-service (default: 6280)
+- `DAPR_HOST`: The Dapr host address (default: http://localhost)
+
 ## Install dependencies
 
 <!-- STEP

--- a/jobs/python/http/job-scheduler/app.py
+++ b/jobs/python/http/job-scheduler/app.py
@@ -55,18 +55,18 @@ def main():
     time.sleep(5)
     
     dapr_host = os.getenv('DAPR_HOST', 'http://localhost')
-    scheduler_dapr_http_port = os.getenv('SCHEDULER_DAPR_HTTP_PORT', '6280')
+    job_service_dapr_http_port = os.getenv('JOB_SERVICE_DAPR_HTTP_PORT', '6280')
     
     # Schedule R2-D2 job
-    schedule_job(dapr_host, scheduler_dapr_http_port, "R2-D2", R2D2_JOB_BODY)
+    schedule_job(dapr_host, job_service_dapr_http_port, "R2-D2", R2D2_JOB_BODY)
     time.sleep(5)
     
     # Schedule C-3PO job
-    schedule_job(dapr_host, scheduler_dapr_http_port, "C-3PO", C3PO_JOB_BODY)
+    schedule_job(dapr_host, job_service_dapr_http_port, "C-3PO", C3PO_JOB_BODY)
     time.sleep(5)
     
     # Get C-3PO job details
-    get_job_details(dapr_host, scheduler_dapr_http_port, "C-3PO")
+    get_job_details(dapr_host, job_service_dapr_http_port, "C-3PO")
     time.sleep(5)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Renamed `schedulerDaprHttpPort` to `jobServiceDaprHttpPort` since this port (6280) belongs to the job-service's Dapr sidecar that the scheduler connects to, not the scheduler itself. This makes the code clearer about the relationships.

Also note the env vars for the python example.