### PR TITLE
Update Dapr.Workflow to 1.15.4

### DIFF
--- a/tutorials/workflow/csharp/child-workflows/ChildWorkflows/ChildWorkflows.csproj
+++ b/tutorials/workflow/csharp/child-workflows/ChildWorkflows/ChildWorkflows.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/workflow/csharp/combined-patterns/WorkflowApp/WorkflowApp.csproj
+++ b/tutorials/workflow/csharp/combined-patterns/WorkflowApp/WorkflowApp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/workflow/csharp/external-system-interaction/ExternalEvents/ExternalEvents.csproj
+++ b/tutorials/workflow/csharp/external-system-interaction/ExternalEvents/ExternalEvents.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/workflow/csharp/fan-out-fan-in/FanOutFanIn/FanOutFanIn.csproj
+++ b/tutorials/workflow/csharp/fan-out-fan-in/FanOutFanIn/FanOutFanIn.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/workflow/csharp/fundamentals/Basic/Basic.csproj
+++ b/tutorials/workflow/csharp/fundamentals/Basic/Basic.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/workflow/csharp/monitor-pattern/Monitor/Monitor.csproj
+++ b/tutorials/workflow/csharp/monitor-pattern/Monitor/Monitor.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/workflow/csharp/resiliency-and-compensation/ResiliencyAndCompensation/ResiliencyAndCompensation.csproj
+++ b/tutorials/workflow/csharp/resiliency-and-compensation/ResiliencyAndCompensation/ResiliencyAndCompensation.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/workflow/csharp/task-chaining/TaskChaining/TaskChaining.csproj
+++ b/tutorials/workflow/csharp/task-chaining/TaskChaining/TaskChaining.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/tutorials/workflow/csharp/workflow-management/WorkflowManagement/WorkflowManagement.csproj
+++ b/tutorials/workflow/csharp/workflow-management/WorkflowManagement/WorkflowManagement.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.3" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>

--- a/workflows/csharp/sdk/order-processor/WorkflowConsoleApp.csproj
+++ b/workflows/csharp/sdk/order-processor/WorkflowConsoleApp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapr.Workflow" Version="1.15.0" />
+    <PackageReference Include="Dapr.Workflow" Version="1.15.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Description

Update the .NET SDK to the 1.15.4 to prevent worfklow issues due to grpc connections. [Issue 1523](https://github.com/dapr/dotnet-sdk/pull/1523).

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
