### PR TITLE
Provide default DAPR_HTTP_PORT fallback (3500) in state_management/javascript.

### DIFF
--- a/state_management/javascript/http/order-processor/index.js
+++ b/state_management/javascript/http/order-processor/index.js
@@ -6,7 +6,7 @@ const DAPR_HOST = process.env.DAPR_HOST ?? "localhost"
 let port  
 switch (protocol) {
   case "http": {
-    port = process.env.DAPR_HTTP_PORT
+    port = process.env.DAPR_HTTP_PORT ?? 3500
     break
   }
   case "grpc": {


### PR DESCRIPTION
# Description

The switch logic is inconsistent. Although `DAPR_PROTOCOL` defaults to `"http"` when unset, the `http` case doesn’t provide a default for `DAPR_HTTP_PORT`. Instead, the switch’s `default` clause falls back to `port = 3500`, which should also apply when `DAPR_PROTOCOL` is `"http"` but `DAPR_HTTP_PORT` is undefined.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
