### PR TITLE
Updated request url to alpha2 and updated quickstart to support toolcalling

### DIFF
--- a/conversation/javascript/http/README.md
+++ b/conversation/javascript/http/README.md
@@ -34,8 +34,11 @@ npm install
 <!-- STEP
 name: Run multi app run template
 expected_stdout_lines:
-  - '== APP - conversation == Input sent: What is dapr?'
+  - '== APP - conversation == Conversation input sent: What is dapr?'
   - '== APP - conversation == Output response: What is dapr?'
+  - '== APP - conversation == Tool calling input sent: What is the weather like in San Francisco in celsius?'
+  - '== APP - conversation == Output message: What is the weather like in San Francisco in celsius?'
+  - '== APP - conversation == No tool calls in response'
 expected_stderr_lines:
 output_match_mode: substring
 match_order: none
@@ -50,12 +53,22 @@ dapr run -f .
 
 The terminal console output should look similar to this, where:
 
-- The app sends an input `What is dapr?` to the `echo` Component mock LLM.
+- The app first sends an input `What is dapr?` to the `echo` Component mock LLM.
 - The mock LLM echoes `What is dapr?`.
 
 ```text
-== APP - conversation == Input sent: What is dapr?
-== APP - conversation == Output response: What is dapr?
+== APP == Conversation input sent: What is dapr?
+== APP == Output response: What is dapr?
+```
+
+- The app then sends an input `What is the weather like in San Francisco in celsius?` to the `echo` Component mock LLM.
+- The mock LLM echoes `What is the weather like in San Francisco in celsius?` and calls the `get_weather` tool.
+- Since we are using the `echo` Component mock LLM, the tool call is not executed and the LLM returns `No tool calls in response`.
+
+```text
+== APP == Tool calling input sent: What is the weather like in San Francisco in celsius?
+== APP == Output message: What is the weather like in San Francisco in celsius?
+== APP == No tool calls in response
 ```
 
 <!-- END_STEP -->
@@ -90,10 +103,15 @@ dapr run --app-id conversation --resources-path ../../../components/ -- npm run 
 
 The terminal console output should look similar to this, where:
 
-- The app sends an input `What is dapr?` to the `echo` Component mock LLM.
+- The app first sends an input `What is dapr?` to the `echo` Component mock LLM.
 - The mock LLM echoes `What is dapr?`.
+- The app then sends an input `What is the weather like in San Francisco in celsius?` to the `echo` Component mock LLM.
+- The mock LLM echoes `What is the weather like in San Francisco in celsius?`
 
 ```text
-== APP - conversation == Input sent: What is dapr?
+== APP - conversation == Conversation input sent: What is dapr?
 == APP - conversation == Output response: What is dapr?
+== APP - conversation == Tool calling input sent: What is the weather like in San Francisco in celsius?
+== APP - conversation == Output message: What is the weather like in San Francisco in celsius?
+== APP - conversation == No tool calls in response
 ```

--- a/conversation/javascript/http/conversation/index.js
+++ b/conversation/javascript/http/conversation/index.js
@@ -4,29 +4,124 @@ async function main() {
   const daprHost = process.env.DAPR_HOST || "http://localhost";
   const daprHttpPort = process.env.DAPR_HTTP_PORT || "3500";
 
-  const inputBody = {
-    name: "echo",
-    inputs: [{ content: "What is dapr?" }],
-    parameters: {},
-    metadata: {},
-  };
+  const reqURL = `${daprHost}:${daprHttpPort}/v1.0-alpha2/conversation/${conversationComponentName}/converse`;
 
-  const reqURL = `${daprHost}:${daprHttpPort}/v1.0-alpha1/conversation/${conversationComponentName}/converse`;
-
+  // Plain conversation
   try {
+    const converseInputBody = {
+      name: conversationComponentName,
+      inputs: [
+        {
+          messages: [
+            {
+              of_user: {
+                content: [
+                  {
+                    text: "What is dapr?",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      parameters: {},
+      metadata: {},
+    };
     const response = await fetch(reqURL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(inputBody),
+      body: JSON.stringify(converseInputBody),
     });
 
-    console.log("Input sent: What is dapr?");
+    console.log("Conversation input sent: What is dapr?");
 
     const data = await response.json();
-    const result = data.outputs[0].result;
+    const result = data.outputs[0].choices[0].message.content;
     console.log("Output response:", result);
+  } catch (error) {
+    console.error("Error:", error.message);
+    process.exit(1);
+  }
+
+  // Tool calling
+  try {
+    const toolCallingInputBody = {
+      name: conversationComponentName,
+      inputs: [
+        {
+          messages: [
+            {
+              of_user: {
+                content: [
+                  {
+                    text: "What is the weather like in San Francisco in celsius?",
+                  },
+                ],
+              },
+            },
+          ],
+          scrub_pii: false,
+        },
+      ],
+      metadata: {
+        api_key: "test-key",
+        version: "1.0",
+      },
+      scrub_pii: false,
+      temperature: 0.7,
+      tools: [
+        {
+          function: {
+            name: "get_weather",
+            description: "Get the current weather for a location",
+            parameters: {
+              type: "object",
+              properties: {
+                location: {
+                  type: "string",
+                  description: "The city and state, e.g. San Francisco, CA",
+                },
+                unit: {
+                  type: "string",
+                  enum: ["celsius", "fahrenheit"],
+                  description: "The temperature unit to use",
+                },
+              },
+              required: ["location"],
+            },
+          },
+        },
+      ],
+      tool_choice: "auto",
+    };
+    const response = await fetch(reqURL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toolCallingInputBody),
+    });
+
+    console.log(
+      "Tool calling input sent: What is the weather like in San Francisco in celsius?"
+    );
+
+    const data = await response.json();
+
+    const result = data?.outputs?.[0]?.choices?.[0]?.message?.content;
+    console.log("Output message:", result);
+
+    if (data?.outputs?.[1]?.choices?.[0]?.message?.toolCalls) {
+      console.log(
+        "Output message:",
+        JSON.stringify(data.outputs[1].choices[0].message?.toolCalls, null, 2)
+      );
+    } else {
+      console.log("No tool calls in response");
+    }
   } catch (error) {
     console.error("Error:", error.message);
     process.exit(1);


### PR DESCRIPTION
# Description

- Changed the request URL to use the new API on `v1.0-alpha2` 
- Updated the example to work with the new protos
- Extended the example to include tool-calling

## Issue reference

https://github.com/dapr/quickstarts/issues/1207

https://github.com/dapr/quickstarts/issues/1210

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [X] You've updated the quickstart's README if necessary
* [X] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
