### PR TITLE
Update Dockerfile to use .NET SDK and runtime version 8.0

### DIFF
--- a/tutorials/distributed-calculator/csharp/Dockerfile
+++ b/tutorials/distributed-calculator/csharp/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official .NET 7 SDK image to build the application
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 
 # Copy the project file and restore dependencies
@@ -12,7 +12,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Use the official .NET 7 runtime image to run the application
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
 


### PR DESCRIPTION
# Description

build pipeline failing due to version mismatch
