### PR TITLE
Update conversation echo python README for http

### DIFF
--- a/conversation/python/http/README.md
+++ b/conversation/python/http/README.md
@@ -40,9 +40,9 @@ expected_stdout_lines:
   - '== APP - conversation == Tool calling input sent: What is the weather like in San Francisco in celsius?'
   - '== APP - conversation == Output message: What is the weather like in San Francisco in celsius?'
   - '== APP - conversation == Tool calls detected:'
-  - "== APP - conversation == Tool call: {'id': '0', 'function': {'name': 'get_weather', 'arguments': 'location,unit'}}"
+  - "== APP - conversation == Tool call: {'id': '0', 'function': {'name': 'get_weather', 'arguments':"
   - '== APP - conversation == Function name: get_weather'
-  - '== APP - conversation == Function arguments: location,unit'
+  - '== APP - conversation == Function arguments: '
 expected_stderr_lines:
 output_match_mode: substring
 match_order: none


### PR DESCRIPTION
# Description

The echo provider in components contrib changed to be similar to regular LLM providers returning a single output and also returning information about tool calls if there were tools to "mimic" a bit of LLM behavior

@marcduiker related to https://github.com/dapr/quickstarts/pull/1241 on the python error

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
