### PR TITLE
fix flake test in conversation js per echo provider golang map key unsorted

### DIFF
--- a/conversation/javascript/http/README.md
+++ b/conversation/javascript/http/README.md
@@ -38,7 +38,7 @@ expected_stdout_lines:
   - '== APP - conversation == Output response: What is dapr?'
   - '== APP - conversation == Tool calling input sent: What is the weather like in San Francisco in celsius?'
   - '== APP - conversation == Output message: What is the weather like in San Francisco in celsius?'
-  - '== APP - conversation == Tool calls detected: [{"id":"0","function":{"name":"get_weather","arguments":"location,unit"}}]'
+  - '== APP - conversation == Tool calls detected: [{"id":"0","function":{"name":"get_weather","arguments":'
 expected_stderr_lines:
 output_match_mode: substring
 match_order: none


### PR DESCRIPTION
# Description

workaround fix flake on javascript test as echo provider is not returning deterministic keys in order. Flakes shown as in https://github.com/dapr/quickstarts/actions/runs/17432891268/job/49497951309

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
