### PR TITLE
Using root level props file to avoid per-project configuration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+﻿<Project>
+    <PropertyGroup>
+        <TargetFramework>net8</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <NoWarn>$(NoWarn);DAPR_CONVERSATION;DAPR_JOBS;DAPR_DISTRIBUTEDLOCK;DAPR_CRYPTOGRAPHY</NoWarn>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
# Description

Adding root directory.build.props file to provide a common place for properties (so we don't have to set the NoWarn or TargetFramework properties for each csproj across the increasingly larger solution.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Discussed on the release call 9/4/2025

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
