### PR TITLE
Fix #1250 KeyNotFoundException in conversation quickstart tool calling

### DIFF
--- a/conversation/csharp/http/conversation/Program.cs
+++ b/conversation/csharp/http/conversation/Program.cs
@@ -30,7 +30,6 @@ var httpClient = new HttpClient();
 
 var conversationRequestBody = JsonSerializer.Deserialize<Dictionary<string, object?>>("""
   {
-    "name": "echo",
     "inputs": [{
       "messages": [{
         "of_user": {
@@ -67,7 +66,6 @@ Console.WriteLine($"Output response: {conversationContent}");
 
 var toolCallRequestBody = JsonSerializer.Deserialize<Dictionary<string, object?>>("""
   {
-    "name": "demo",
     "inputs": [
       {
         "messages": [
@@ -135,24 +133,20 @@ var toolCallRequestBody = JsonSerializer.Deserialize<Dictionary<string, object?>
 var toolCallingResponse = await httpClient.PostAsJsonAsync("http://localhost:3500/v1.0-alpha2/conversation/echo/converse", toolCallRequestBody);
 var toolCallingResult = await toolCallingResponse.Content.ReadFromJsonAsync<JsonElement>();
 
-var toolCallingContent = toolCallingResult
+var messageElement = toolCallingResult
   .GetProperty("outputs")
   .EnumerateArray()
   .First()
   .GetProperty("choices")
   .EnumerateArray()
   .First()
-  .GetProperty("message")
-  .GetProperty("content");
+  .GetProperty("message");
 
-var functionCalled = toolCallingResult
-  .GetProperty("outputs")
-  .EnumerateArray()
-  .First()
-  .GetProperty("choices")
-  .EnumerateArray()
-  .First()
-  .GetProperty("message")
+var toolCallingContent = messageElement.TryGetProperty("content", out var contentElement) 
+    ? contentElement.GetString() 
+    : null;
+
+var functionCalled = messageElement
   .GetProperty("toolCalls")
   .EnumerateArray()
   .First()


### PR DESCRIPTION
# Description

 - Fix for the reported bug #1250 
 - Also removed name in the request body as component name should come from the URL
 

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

#1250 1250

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
