### PR TITLE
Align sample field names with docs using camelCase notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ out/
 **/.dapr/deploy
 # Auto generated logs dir inside .dapr directory
 **/.dapr/logs
+/.cursor/

--- a/conversation/csharp/http/conversation/Program.cs
+++ b/conversation/csharp/http/conversation/Program.cs
@@ -32,7 +32,7 @@ var conversationRequestBody = JsonSerializer.Deserialize<Dictionary<string, obje
   {
     "inputs": [{
       "messages": [{
-        "of_user": {
+        "ofUser": {
           "content": [{
             "text": "What is dapr?"
           }]
@@ -70,7 +70,7 @@ var toolCallRequestBody = JsonSerializer.Deserialize<Dictionary<string, object?>
       {
         "messages": [
           {
-            "of_user": {
+            "ofUser": {
               "content": [
                 {
                   "text": "What is the weather like in San Francisco in celsius?"
@@ -79,7 +79,7 @@ var toolCallRequestBody = JsonSerializer.Deserialize<Dictionary<string, object?>
             }
           }
         ],
-        "scrubPII": false
+        "scrubPii": false
       }
     ],
     "parameters": {

--- a/conversation/go/http/conversation/conversation.go
+++ b/conversation/go/http/conversation/conversation.go
@@ -45,7 +45,7 @@ func main() {
 		"name": "echo",
 		"inputs": [{
 			"messages": [{
-				"of_user": {
+				"ofUser": {
 					"content": [{
 						"text": "What is dapr?"
 					}]
@@ -101,7 +101,7 @@ func main() {
 		"name": "echo",
 		"inputs": [{
 			"messages": [{
-				"of_user": {
+				"ofUser": {
 					"content": [{
 						"text": "What is the weather like in San Francisco in celsius?"
 					}]

--- a/conversation/javascript/http/conversation/index.js
+++ b/conversation/javascript/http/conversation/index.js
@@ -14,7 +14,7 @@ async function main() {
         {
           messages: [
             {
-              of_user: {
+              ofUser: {
                 content: [
                   {
                     text: "What is dapr?",
@@ -54,7 +54,7 @@ async function main() {
         {
           messages: [
             {
-              of_user: {
+              ofUser: {
                 content: [
                   {
                     text: "What is the weather like in San Francisco in celsius?",
@@ -63,14 +63,14 @@ async function main() {
               },
             },
           ],
-          scrub_pii: false,
+          scrubPii: false,
         },
       ],
       metadata: {
         api_key: "test-key",
         version: "1.0",
       },
-      scrub_pii: false,
+      scrubPii: false,
       temperature: 0.7,
       tools: [
         {
@@ -95,7 +95,7 @@ async function main() {
           },
         },
       ],
-      tool_choice: "auto",
+      toolChoice: "auto",
     };
     const response = await fetch(reqURL, {
       method: "POST",

--- a/conversation/python/http/conversation/app.py
+++ b/conversation/python/http/conversation/app.py
@@ -29,7 +29,7 @@ input = {
     'name': 'anthropic',
     'inputs': [{
         'messages': [{
-            'of_user': {
+            'ofUser': {
                 'content': [{
                     'text': 'What is dapr?'
                 }]
@@ -69,13 +69,13 @@ tool_call_input = {
     'name': 'anthropic',
     'inputs': [{
         'messages': [{
-            'of_user': {
+            'ofUser': {
                 'content': [{
                     'text': 'What is the weather like in San Francisco in celsius?'
                 }]
             }
         }],
-        'scrubPII': False
+        'scrubPii': False
     }],
     'parameters': {
         'max_tokens': {


### PR DESCRIPTION
# Description

Align field names with Dapr documentation by converting to preferred camelCase notation. Updated of_user → ofUser, scrub_pii → scrubPii, and tool_choice → toolChoice across C#, Go, and JavaScript examples.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [x] You've updated the quickstart's README if necessary
* [x] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
