### PR TITLE
HTTPS redirection is a known issue with the Dapr SDK - removing from quickstart test

### DIFF
--- a/actors/csharp/sdk/service/Program.cs
+++ b/actors/csharp/sdk/service/Program.cs
@@ -14,19 +14,6 @@ builder.Services.AddActors(options =>
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseDeveloperExceptionPage();
-}
-else
-{
-    // By default, ASP.Net Core uses port 5000 for HTTP. The HTTP
-    // redirection will interfere with the Dapr runtime. You can
-    // move this out of the else block if you use port 5001 in this
-    // example, and developer tooling (such as the VSCode extension).
-    app.UseHttpsRedirection();
-}
-
 app.MapActorsHandlers();
 
 app.Run();


### PR DESCRIPTION
# Description

Upon report that the Actors .NET SDK isn't working, I've explored reasons why - this is likely one of them.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] The quickstart code compiles correctly
* [X] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
