### PR TITLE
feat(python): Enable Multi-App Run for Python HTTP and SDK bindings q…

### DIFF
--- a/bindings/python/http/README.md
+++ b/bindings/python/http/README.md
@@ -1,18 +1,27 @@
 # Dapr Bindings (HTTP)
 
-In this quickstart, you'll create a microservice to demonstrate Dapr's bindings API to work with external systems as inputs and outputs. The service listens to input binding events from a system CRON and then outputs the contents of local data to a PostreSql output binding. 
+In this quickstart, you'll create a microservice to demonstrate Dapr's bindings API to work with external systems as inputs and outputs. The service listens to input binding events from a system CRON and then outputs the contents of local data to a PostgreSQL output binding.
 
 Visit [this](https://docs.dapr.io/developing-applications/building-blocks/bindings/) link for more information about Dapr and Bindings.
 
-> **Note:** This example leverages only HTTP REST.  If you are looking for the example using the Dapr SDK [click here](../sdk).
+> **Note:** This example leverages only HTTP REST. If you are looking for the example using the Dapr SDK [click here](../sdk).
 
 This quickstart includes one service:
- 
-- Python service `batch`
 
-### Run and initialize PostgreSQL container
+- Python service `batch-http`
 
-1. Open a new terminal, change directories to `../../db`, and run the container with [Docker Compose](https://docs.docker.com/compose/): 
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
+- Python 3.x
+- Initialize Dapr: `dapr init`
+
+---
+
+## Run and initialize PostgreSQL container
+
+1. Open a new terminal, change directories to `../../db`, and run the container with [Docker Compose](https://docs.docker.com/compose/):
 
 <!-- STEP
 name: Run and initialize PostgreSQL container
@@ -28,9 +37,11 @@ docker compose up -d
 
 <!-- END_STEP -->
 
-### Run Python service with Dapr
+---
 
-2. Open a new terminal window, change directories to `./batch` in the quickstart directory and run: 
+## Run Python service with Dapr
+
+2. Open a new terminal window, change directories to `./batch` in the quickstart directory and run:
 
 <!-- STEP
 name: Install python dependencies
@@ -44,7 +55,9 @@ cd ..
 
 <!-- END_STEP -->
 
-3. Run the Python service app with Dapr:
+---
+
+3. From the quickstart directory `bindings/python/http`, run the Python service app with Dapr:
 
 <!-- STEP
 name: Run batch-http service
@@ -61,6 +74,31 @@ timeout_seconds: 60
 
 ```bash
 dapr run -f .
+```
+
+<!-- END_STEP -->
+
+The `-f` flag runs the application using the **Multi-App Run configuration** defined in `dapr.yaml`, automatically starting both the application and its Dapr sidecar.
+
+The cron input binding triggers the service every 10 seconds, and the service writes records to PostgreSQL using the output binding.
+
+---
+
+## Verify Data Persistence
+
+4. Open a new terminal window and run the following command to check the rows in the database:
+
+<!-- STEP
+name: Verify Data Persistence
+expected_stdout_lines:
+  - 'orderid |  customer  | price'
+  - '---------+------------+--------'
+expected_stderr_lines:
+output_match_mode: substring
+-->
+
+```bash
+docker exec postgres psql -U postgres -d orders -c "SELECT * FROM orders;"
 ```
 
 <!-- END_STEP -->

--- a/bindings/python/http/batch/app.py
+++ b/bindings/python/http/batch/app.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 #
-# From the quickstart directory `bindings/python/http`, run the python service app with Dapr:
+# From the quickstart directory `bindings/python/http`, run the Python service app with Dapr:
 #   dapr run -f .
 
 import json

--- a/bindings/python/http/batch/app.py
+++ b/bindings/python/http/batch/app.py
@@ -10,8 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# dapr run --app-id batch-http --app-port 50051
-#   --resources-path ../../../components -- python3 app.py
+#
+# From the quickstart directory `bindings/python/http`, run the python service app with Dapr:
+#   dapr run -f .
 
 import json
 from flask import Flask
@@ -21,7 +22,7 @@ import os
 app = Flask(__name__)
 
 app_port = os.getenv('APP_PORT', '5001')
-dapr_port = os.getenv('DAPR_HTTP_PORT', '4001')
+dapr_port = os.getenv('DAPR_HTTP_PORT', '3500')
 base_url = os.getenv('BASE_URL', 'http://localhost')
 cron_binding_name = 'cron'
 sql_binding_name = 'sqldb'

--- a/bindings/python/http/dapr.yaml
+++ b/bindings/python/http/dapr.yaml
@@ -2,6 +2,6 @@ version: 1
 apps:
   - appID: batch-http
     appDirPath: ./batch
-    appPort: 50051
+    appPort: 5001
     command: ["python3", "app.py"]
     resourcesPath: ../../../components

--- a/bindings/python/sdk/README.md
+++ b/bindings/python/sdk/README.md
@@ -1,18 +1,27 @@
 # Dapr Bindings (Dapr SDK)
 
-In this quickstart, you'll create a microservice to demonstrate Dapr's bindings API to work with external systems as inputs and outputs. The service listens to input binding events from a system CRON and then outputs the contents of local data to a PostreSql output binding. 
+In this quickstart, you'll create a microservice to demonstrate Dapr's bindings API to work with external systems as inputs and outputs. The service listens to input binding events from a system CRON and then outputs the contents of local data to a PostgreSQL output binding.
 
 Visit [this](https://docs.dapr.io/developing-applications/building-blocks/bindings/) link for more information about Dapr and Bindings.
 
-> **Note:** This example leverages the Dapr SDK.  If you are looking for the example using HTTP REST only [click here](../http).
+> **Note:** This example leverages the Dapr SDK. If you are looking for the example using HTTP REST only [click here](../http).
 
 This quickstart includes one service:
- 
-- Python service `batch`
 
-### Run and initialize PostgreSQL container
+- Python service `batch-sdk`
 
-1. Open a new terminal, change directories to `../../db`, and run the container with [Docker Compose](https://docs.docker.com/compose/): 
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
+- Python 3.x
+- Initialize Dapr: `dapr init`
+
+---
+
+## Run and initialize PostgreSQL container
+
+1. Open a new terminal, change directories to `../../db`, and run the container with [Docker Compose](https://docs.docker.com/compose/):
 
 <!-- STEP
 name: Run and initialize PostgreSQL container
@@ -28,9 +37,11 @@ docker compose up -d
 
 <!-- END_STEP -->
 
-### Run Python service with Dapr
+---
 
-2. Open a new terminal window, change directories to `./batch` in the quickstart directory and run: 
+## Run Python service with Dapr
+
+2. Open a new terminal window, change directories to `./batch` in the quickstart directory and run:
 
 <!-- STEP
 name: Install python dependencies
@@ -44,7 +55,9 @@ cd ..
 
 <!-- END_STEP -->
 
-3. Run the Python service app with Dapr:
+---
+
+3. From the quickstart directory `bindings/python/sdk`, run the Python service app with Dapr:
 
 <!-- STEP
 name: Run batch-sdk service
@@ -61,6 +74,31 @@ timeout_seconds: 60
 
 ```bash
 dapr run -f .
+```
+
+<!-- END_STEP -->
+
+The `-f` flag runs the application using the **Multi-App Run configuration** defined in `dapr.yaml`, automatically starting both the application and its Dapr sidecar.
+
+The cron input binding triggers the service every 10 seconds, and the service writes records to PostgreSQL using the output binding.
+
+---
+
+## Verify Data Persistence
+
+4. Open a new terminal window and run the following command to check the rows in the database:
+
+<!-- STEP
+name: Verify Data Persistence
+expected_stdout_lines:
+  - 'orderid |  customer  | price'
+  - '---------+------------+--------'
+expected_stderr_lines:
+output_match_mode: substring
+-->
+
+```bash
+docker exec postgres psql -U postgres -d orders -c "SELECT * FROM orders;"
 ```
 
 <!-- END_STEP -->

--- a/bindings/python/sdk/batch/app.py
+++ b/bindings/python/sdk/batch/app.py
@@ -10,8 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# dapr run --app-id batch-sdk --app-port 50051
-#   --resources-path ../../../components -- python3 app.py
+#
+# From the quickstart directory `bindings/python/sdk`, run the python service app with Dapr:
+#   dapr run -f .
 
 import json
 from flask import Flask

--- a/bindings/python/sdk/batch/app.py
+++ b/bindings/python/sdk/batch/app.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 #
-# From the quickstart directory `bindings/python/sdk`, run the python service app with Dapr:
+# From the quickstart directory `bindings/python/sdk`, run the Python service app with Dapr:
 #   dapr run -f .
 
 import json

--- a/bindings/python/sdk/dapr.yaml
+++ b/bindings/python/sdk/dapr.yaml
@@ -2,6 +2,6 @@ version: 1
 apps:
   - appID: batch-sdk
     appDirPath: ./batch
-    appPort: 50051
+    appPort: 5001
     command: ["python3", "app.py"]
     resourcesPath: ../../../components


### PR DESCRIPTION
# Description

This PR enables **Dapr Multi-App Run** for the Python bindings quickstarts (**HTTP and SDK**).

Previously, the Python quickstarts required running the application using a long `dapr run` command with multiple flags:

```bash
dapr run --app-id batch-http --app-port 50051 --resources-path ../../../components -- python3 app.py
```

With this change, the quickstarts can now be started using the simplified Multi-App Run configuration:

```bash
dapr run -f .
```

This aligns the Python quickstarts with the already updated Java and JavaScript bindings quickstarts and improves the onboarding experience by reducing manual setup.

## Changes

- Added Multi-App Run configuration using `dapr.yaml`
- Updated `README.md` instructions to use `dapr run -f .`
- Added a **Prerequisites** section
- Added a **Verify Data Persistence** step
- Updated `appPort` from `50051` to `5001` to match the Flask application
- Standardized `DAPR_HTTP_PORT` to `3500`
- Ensured `resourcesPath` correctly points to `../../../components`
- Updated quickstarts:
  - `bindings/python/http`
  - `bindings/python/sdk`

## Verification

Tested locally.

### 1. Start the database

```bash
cd bindings/db
docker compose up -d
```

### 2. Install dependencies

For HTTP quickstart:

```bash
cd bindings/python/http/batch
pip3 install -r requirements.txt
```

For SDK quickstart:

```bash
cd bindings/python/sdk/batch
pip3 install -r requirements.txt
```

### 3. Run the quickstart

```bash
cd ..
dapr run -f .
```

### Observed behavior

- Python service starts successfully
- Dapr sidecar initializes
- Cron binding triggers every 10 seconds
- Orders are inserted into PostgreSQL

**Example output:**

```
Processing batch..
insert into orders (orderid, customer, price) values (1, 'John Smith', 100.32)
insert into orders (orderid, customer, price) values (2, 'Jane Bond', 15.4)
insert into orders (orderid, customer, price) values (3, 'Tony James', 35.56)
Finished processing batch
```

### Verify database persistence

```bash
docker exec postgres psql -U postgres -d orders -c "SELECT * FROM orders;"
```

Rows increase over time confirming the full end-to-end flow.

### Automated validation

Validation was also verified locally using `mechanical-markdown`:

```bash
mm.py -l -s "bash -c" README.md
```

## Checklist

- [x] The quickstart code compiles correctly
- [x] The quickstart was tested locally
- [x] README has been updated
- [x] Automated validation annotations remain compatible with `mechanical-markdown`
