### PR TITLE
Remove fastapi_cloudevents since it's not compatible with the latest cloudevents package.

### DIFF
--- a/tutorials/workflow/python/combined-patterns/shipping_app/app.py
+++ b/tutorials/workflow/python/combined-patterns/shipping_app/app.py
@@ -1,10 +1,14 @@
+from typing import Any
 from fastapi import FastAPI, status
+from pydantic import BaseModel
 from dapr.clients import DaprClient
 from models import Order, CustomerInfo, ShipmentRegistrationStatus, ShippingDestinationResult
-from fastapi_cloudevents import CloudEvent
 import uvicorn
 
 app = FastAPI()
+
+class CloudEvent(BaseModel):
+    data: Any
 
 DAPR_PUBSUB_COMPONENT = "shippingpubsub"
 DAPR_PUBSUB_CONFIRMED_TOPIC = "shipment-registration-confirmed-events"

--- a/tutorials/workflow/python/combined-patterns/shipping_app/requirements.txt
+++ b/tutorials/workflow/python/combined-patterns/shipping_app/requirements.txt
@@ -1,6 +1,5 @@
 dapr>=1.17.0
 dapr-ext-workflow>=1.17.0
 fastapi>=0.115.0
-fastapi-cloudevents>=2.0.2
 pydantic>=2.11.4
 uvicorn>=0.34.2

--- a/tutorials/workflow/python/combined-patterns/workflow_app/app.py
+++ b/tutorials/workflow/python/combined-patterns/workflow_app/app.py
@@ -1,8 +1,9 @@
+from typing import Any
 from fastapi import FastAPI, status
+from pydantic import BaseModel
 from contextlib import asynccontextmanager
 from order_workflow import wf_runtime, order_workflow, SHIPMENT_REGISTERED_EVENT
 from models import Order, ShipmentRegistrationStatus
-from fastapi_cloudevents import CloudEvent
 import inventory_management as im
 import dapr.ext.workflow as wf
 import uvicorn
@@ -14,6 +15,9 @@ async def lifespan(app: FastAPI):
     wf_runtime.shutdown()
 
 app = FastAPI(lifespan=lifespan)
+
+class CloudEvent(BaseModel):
+    data: Any
 
 @app.post("/start", status_code=status.HTTP_202_ACCEPTED)
 async def start_workflow(order: Order) -> None:

--- a/tutorials/workflow/python/combined-patterns/workflow_app/requirements.txt
+++ b/tutorials/workflow/python/combined-patterns/workflow_app/requirements.txt
@@ -1,6 +1,5 @@
 dapr>=1.17.0
 dapr-ext-workflow>=1.17.0
 fastapi>=0.115.0
-fastapi-cloudevents>=2.0.2
 pydantic>=2.11.4
 uvicorn>=0.34.2


### PR DESCRIPTION
# Description

Remove _fastapi-cloudevents_ dependency since it breaks the combined patterns workflow tutorial.

**Analysis by Claude**
The fastapi-cloudevents library (latest 2.0.2) is incompatible with the newly released cloudevents 2.0.0.

Evidence chain:
  1. fastapi-cloudevents==2.0.2 metadata declares Requires-Dist: cloudevents[pydantic] — with no upper-bound pin.
  2. Its module fastapi_cloudevents/cloudevent.py does import cloudevents.pydantic.                  
  3. That cloudevents.pydantic submodule existed in cloudevents 1.x (1.6.0 – 1.12.1), but cloudevents 2.0.0
  (released recently) restructured the API — the submodule is gone, replaced by cloudevents.core.bindings.http   
  (which the working pub_sub/python/sdk/order-processor/app.py already uses, per commit ae1fe8f4 "Update to      
  latest cloudevents").
  4. tutorials/workflow/python/combined-patterns/{shipping_app,workflow_app}/requirements.txt pin
  fastapi-cloudevents>=2.0.2 with no cloudevents constraint, so a fresh pip install resolves cloudevents==2.0.0  
  and the import blows up.
  5. fastapi-cloudevents has not published a release compatible with cloudevents>=2.0; 2.0.2 is still the latest 
  on PyPI.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
