### PR TITLE
chore(java): bump Dapr SDK pins to 1.18.0-rc-1

### DIFF
--- a/bindings/java/sdk/batch/pom.xml
+++ b/bindings/java/sdk/batch/pom.xml
@@ -28,12 +28,12 @@
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk-springboot</artifactId>
-			<version>1.17.0-rc-3</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.17.0</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/configuration/java/sdk/order-processor/pom.xml
+++ b/configuration/java/sdk/order-processor/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.17.0</version>
+            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/conversation/java/sdk/conversation/pom.xml
+++ b/conversation/java/sdk/conversation/pom.xml
@@ -22,7 +22,7 @@
       <dependency>
         <groupId>io.dapr</groupId>
         <artifactId>dapr-sdk</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0-rc-1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jobs/java/sdk/job-scheduler/pom.xml
+++ b/jobs/java/sdk/job-scheduler/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk</artifactId>
-                <version>1.17.0</version>
+                <version>1.18.0-rc-1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/jobs/java/sdk/job-service/pom.xml
+++ b/jobs/java/sdk/job-service/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <springframework.version>3.5.0</springframework.version>
         <springweb.version>6.2.7</springweb.version>
-        <dapr-sdk.version>1.17.0-rc-3</dapr-sdk.version>
+        <dapr-sdk.version>1.18.0-rc-1</dapr-sdk.version>
     </properties>
 
     <dependencies>
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk</artifactId>
-                <version>1.17.0</version>
+                <version>1.18.0-rc-1</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/pub_sub/java/sdk/checkout/pom.xml
+++ b/pub_sub/java/sdk/checkout/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.17.0</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>

--- a/pub_sub/java/sdk/order-processor/pom.xml
+++ b/pub_sub/java/sdk/order-processor/pom.xml
@@ -24,12 +24,12 @@
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk-springboot</artifactId>
-			<version>1.17.0-rc-3</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.17.0</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/secrets_management/java/sdk/order-processor/pom.xml
+++ b/secrets_management/java/sdk/order-processor/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.17.0</version>
+            <version>1.18.0-rc-1</version>
         </dependency>
     </dependencies>
     <build>

--- a/state_management/java/sdk/order-processor/pom.xml
+++ b/state_management/java/sdk/order-processor/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.17.0</version>
+            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/tutorials/workflow/java/child-workflows/pom.xml
+++ b/tutorials/workflow/java/child-workflows/pom.xml
@@ -15,7 +15,7 @@
   <description>Child Workflows Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/combined-patterns/shipping-app/pom.xml
+++ b/tutorials/workflow/java/combined-patterns/shipping-app/pom.xml
@@ -15,7 +15,7 @@
   <description>Shipping App Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/combined-patterns/workflow-app/pom.xml
+++ b/tutorials/workflow/java/combined-patterns/workflow-app/pom.xml
@@ -15,7 +15,7 @@
   <description>Workflow App Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/external-system-interactions/pom.xml
+++ b/tutorials/workflow/java/external-system-interactions/pom.xml
@@ -15,7 +15,7 @@
   <description>External System Events Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/fan-out-fan-in/pom.xml
+++ b/tutorials/workflow/java/fan-out-fan-in/pom.xml
@@ -15,7 +15,7 @@
   <description>Fan Out/In Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/fundamentals/pom.xml
+++ b/tutorials/workflow/java/fundamentals/pom.xml
@@ -15,7 +15,7 @@
   <description>Basic Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/monitor-pattern/pom.xml
+++ b/tutorials/workflow/java/monitor-pattern/pom.xml
@@ -15,7 +15,7 @@
   <description>Monitor Pattern Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/resiliency-and-compensation/pom.xml
+++ b/tutorials/workflow/java/resiliency-and-compensation/pom.xml
@@ -15,7 +15,7 @@
   <description>Resiliency and Compensation Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/task-chaining/pom.xml
+++ b/tutorials/workflow/java/task-chaining/pom.xml
@@ -15,7 +15,7 @@
   <description>Task Chaining Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/versioning/pom.xml
+++ b/tutorials/workflow/java/versioning/pom.xml
@@ -15,7 +15,7 @@
   <description>Workflow versioning Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0-rc-2</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
     <testcontainers.version>1.21.4</testcontainers.version>
   </properties>
   <dependencies>

--- a/tutorials/workflow/java/workflow-management/pom.xml
+++ b/tutorials/workflow/java/workflow-management/pom.xml
@@ -15,7 +15,7 @@
   <description>Workflow Management Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/workflows/java/sdk/order-processor/pom.xml
+++ b/workflows/java/sdk/order-processor/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk-workflows</artifactId>
-            <version>1.17.0-rc-3</version>
+            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
## Summary
- Bumps all `io.dapr:*` Java SDK pins in quickstart samples to `1.18.0-rc-1` (Maven-style tag from dapr/java-sdk)
- Covers 5 artifact types: `dapr-sdk`, `dapr-sdk-springboot`, `dapr-sdk-workflows`, `dapr-spring-boot-starter`, `dapr-spring-boot-starter-test`
- 21 pom.xml files updated across bindings, configuration, conversation, jobs, pub_sub, secrets_management, state_management, workflows, and tutorials/workflow samples
- Part of Dapr 1.18 release prep (release day May 26, 2026)

## Note
- Maven Central publish for `1.18.0-rc-1` is **pending** (not yet available as of 2026-05-19). CI may fail until the artifact lands on Maven Central.
- The git tag `v1.18.0-rc-1` exists on dapr/java-sdk but no GitHub Release object has been created yet.

## Test plan
- [ ] CI matrix passes on Java samples once Maven Central artifact is published
- [ ] Local smoke test: hello-world Java sample
- [ ] Local smoke test: pub-sub Java sample (`pub_sub/java/sdk/`)
- [ ] Local smoke test: state-management Java sample (`state_management/java/sdk/`)
- [ ] Local smoke test: workflow Java sample (`workflows/java/sdk/`)
- [ ] Local smoke test: tutorial workflow samples (`tutorials/workflow/java/`)