### PR TITLE
chore(java): bump Dapr SDK pins to 1.18.0-rc-1 using new BOM

### DIFF
--- a/bindings/java/sdk/batch/pom.xml
+++ b/bindings/java/sdk/batch/pom.xml
@@ -28,12 +28,12 @@
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk-springboot</artifactId>
-			<version>1.17.0-rc-3</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.17.0</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/bindings/java/sdk/batch/pom.xml
+++ b/bindings/java/sdk/batch/pom.xml
@@ -15,6 +15,19 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.dapr.spring</groupId>
+				<artifactId>dapr-spring-bom</artifactId>
+				<version>1.18.0-rc-1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
@@ -28,12 +41,10 @@
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk-springboot</artifactId>
-			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -44,7 +55,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.17.1</version>
 		</dependency>
 	</dependencies>
 

--- a/configuration/java/sdk/order-processor/pom.xml
+++ b/configuration/java/sdk/order-processor/pom.xml
@@ -13,11 +13,23 @@
         <maven.compiler.target>17</maven.compiler.target>
         <slf4jVersion>2.0.13</slf4jVersion>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dapr</groupId>
+                <artifactId>dapr-sdk-bom</artifactId>
+                <version>1.18.0-rc-1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/configuration/java/sdk/order-processor/pom.xml
+++ b/configuration/java/sdk/order-processor/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.17.0</version>
+            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/conversation/java/sdk/conversation/pom.xml
+++ b/conversation/java/sdk/conversation/pom.xml
@@ -21,8 +21,10 @@
     <dependencies>
       <dependency>
         <groupId>io.dapr</groupId>
-        <artifactId>dapr-sdk</artifactId>
+        <artifactId>dapr-sdk-bom</artifactId>
         <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/conversation/java/sdk/conversation/pom.xml
+++ b/conversation/java/sdk/conversation/pom.xml
@@ -22,7 +22,7 @@
       <dependency>
         <groupId>io.dapr</groupId>
         <artifactId>dapr-sdk</artifactId>
-        <version>1.17.0</version>
+        <version>1.18.0-rc-1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jobs/java/sdk/job-scheduler/pom.xml
+++ b/jobs/java/sdk/job-scheduler/pom.xml
@@ -25,13 +25,10 @@
         <dependencies>
             <dependency>
                 <groupId>io.dapr</groupId>
-                <artifactId>dapr-sdk</artifactId>
+                <artifactId>dapr-sdk-bom</artifactId>
                 <version>1.18.0-rc-1</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>2.17.2</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/jobs/java/sdk/job-scheduler/pom.xml
+++ b/jobs/java/sdk/job-scheduler/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk</artifactId>
-                <version>1.17.0</version>
+                <version>1.18.0-rc-1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/jobs/java/sdk/job-service/pom.xml
+++ b/jobs/java/sdk/job-service/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <springframework.version>3.5.0</springframework.version>
         <springweb.version>6.2.7</springweb.version>
-        <dapr-sdk.version>1.17.0-rc-3</dapr-sdk.version>
+        <dapr-sdk.version>1.18.0-rc-1</dapr-sdk.version>
     </properties>
 
     <dependencies>
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk</artifactId>
-                <version>1.17.0</version>
+                <version>1.18.0-rc-1</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/jobs/java/sdk/job-service/pom.xml
+++ b/jobs/java/sdk/job-service/pom.xml
@@ -12,7 +12,6 @@
     <properties>
         <springframework.version>3.5.0</springframework.version>
         <springweb.version>6.2.7</springweb.version>
-        <dapr-sdk.version>1.18.0-rc-1</dapr-sdk.version>
     </properties>
 
     <dependencies>
@@ -42,8 +41,10 @@
         <dependencies>
             <dependency>
                 <groupId>io.dapr</groupId>
-                <artifactId>dapr-sdk</artifactId>
+                <artifactId>dapr-sdk-bom</artifactId>
                 <version>1.18.0-rc-1</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/pub_sub/java/sdk/checkout/pom.xml
+++ b/pub_sub/java/sdk/checkout/pom.xml
@@ -13,11 +13,23 @@
 		<maven.compiler.target>17</maven.compiler.target>
 		<slf4jVersion>2.0.13</slf4jVersion>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.dapr</groupId>
+				<artifactId>dapr-sdk-bom</artifactId>
+				<version>1.18.0-rc-1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>

--- a/pub_sub/java/sdk/checkout/pom.xml
+++ b/pub_sub/java/sdk/checkout/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.17.0</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>

--- a/pub_sub/java/sdk/order-processor/pom.xml
+++ b/pub_sub/java/sdk/order-processor/pom.xml
@@ -16,6 +16,19 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.dapr.spring</groupId>
+				<artifactId>dapr-spring-bom</artifactId>
+				<version>1.18.0-rc-1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -24,12 +37,10 @@
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk-springboot</artifactId>
-			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/pub_sub/java/sdk/order-processor/pom.xml
+++ b/pub_sub/java/sdk/order-processor/pom.xml
@@ -24,12 +24,12 @@
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk-springboot</artifactId>
-			<version>1.17.0-rc-3</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.dapr</groupId>
 			<artifactId>dapr-sdk</artifactId>
-			<version>1.17.0</version>
+			<version>1.18.0-rc-1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/secrets_management/java/sdk/order-processor/pom.xml
+++ b/secrets_management/java/sdk/order-processor/pom.xml
@@ -16,11 +16,23 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dapr</groupId>
+                <artifactId>dapr-sdk-bom</artifactId>
+                <version>1.18.0-rc-1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.18.0-rc-1</version>
         </dependency>
     </dependencies>
     <build>

--- a/secrets_management/java/sdk/order-processor/pom.xml
+++ b/secrets_management/java/sdk/order-processor/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.17.0</version>
+            <version>1.18.0-rc-1</version>
         </dependency>
     </dependencies>
     <build>

--- a/state_management/java/sdk/order-processor/pom.xml
+++ b/state_management/java/sdk/order-processor/pom.xml
@@ -13,11 +13,23 @@
         <maven.compiler.target>17</maven.compiler.target>
         <slf4jVersion>2.0.13</slf4jVersion>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dapr</groupId>
+                <artifactId>dapr-sdk-bom</artifactId>
+                <version>1.18.0-rc-1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/state_management/java/sdk/order-processor/pom.xml
+++ b/state_management/java/sdk/order-processor/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk</artifactId>
-            <version>1.17.0</version>
+            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/tutorials/workflow/java/child-workflows/pom.xml
+++ b/tutorials/workflow/java/child-workflows/pom.xml
@@ -14,9 +14,18 @@
   <name>child-workflows</name>
   <description>Child Workflows Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/child-workflows/pom.xml
+++ b/tutorials/workflow/java/child-workflows/pom.xml
@@ -15,7 +15,7 @@
   <description>Child Workflows Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/combined-patterns/shipping-app/pom.xml
+++ b/tutorials/workflow/java/combined-patterns/shipping-app/pom.xml
@@ -15,7 +15,7 @@
   <description>Shipping App Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/combined-patterns/shipping-app/pom.xml
+++ b/tutorials/workflow/java/combined-patterns/shipping-app/pom.xml
@@ -14,9 +14,18 @@
   <name>shipping-app</name>
   <description>Shipping App Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/combined-patterns/workflow-app/pom.xml
+++ b/tutorials/workflow/java/combined-patterns/workflow-app/pom.xml
@@ -14,9 +14,18 @@
   <name>workflow-app</name>
   <description>Workflow App Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/combined-patterns/workflow-app/pom.xml
+++ b/tutorials/workflow/java/combined-patterns/workflow-app/pom.xml
@@ -15,7 +15,7 @@
   <description>Workflow App Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/external-system-interactions/pom.xml
+++ b/tutorials/workflow/java/external-system-interactions/pom.xml
@@ -14,9 +14,18 @@
   <name>external-system-interactions</name>
   <description>External System Events Workflow Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/external-system-interactions/pom.xml
+++ b/tutorials/workflow/java/external-system-interactions/pom.xml
@@ -15,7 +15,7 @@
   <description>External System Events Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/fan-out-fan-in/pom.xml
+++ b/tutorials/workflow/java/fan-out-fan-in/pom.xml
@@ -14,9 +14,18 @@
   <name>fan-out-fan-in</name>
   <description>Fan Out/In Workflow Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/fan-out-fan-in/pom.xml
+++ b/tutorials/workflow/java/fan-out-fan-in/pom.xml
@@ -15,7 +15,7 @@
   <description>Fan Out/In Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/fundamentals/pom.xml
+++ b/tutorials/workflow/java/fundamentals/pom.xml
@@ -15,7 +15,7 @@
   <description>Basic Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/fundamentals/pom.xml
+++ b/tutorials/workflow/java/fundamentals/pom.xml
@@ -14,9 +14,18 @@
   <name>fundamentals</name>
   <description>Basic Workflow Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/monitor-pattern/pom.xml
+++ b/tutorials/workflow/java/monitor-pattern/pom.xml
@@ -15,7 +15,7 @@
   <description>Monitor Pattern Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/monitor-pattern/pom.xml
+++ b/tutorials/workflow/java/monitor-pattern/pom.xml
@@ -14,9 +14,18 @@
   <name>monitor-pattern</name>
   <description>Monitor Pattern Workflow Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/resiliency-and-compensation/pom.xml
+++ b/tutorials/workflow/java/resiliency-and-compensation/pom.xml
@@ -14,9 +14,18 @@
   <name>resiliency-and-compensation</name>
   <description>Resiliency and Compensation Workflow Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/resiliency-and-compensation/pom.xml
+++ b/tutorials/workflow/java/resiliency-and-compensation/pom.xml
@@ -15,7 +15,7 @@
   <description>Resiliency and Compensation Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/task-chaining/pom.xml
+++ b/tutorials/workflow/java/task-chaining/pom.xml
@@ -15,7 +15,7 @@
   <description>Task Chaining Workflow Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/task-chaining/pom.xml
+++ b/tutorials/workflow/java/task-chaining/pom.xml
@@ -14,9 +14,18 @@
   <name>task-chaining</name>
   <description>Task Chaining Workflow Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/versioning/pom.xml
+++ b/tutorials/workflow/java/versioning/pom.xml
@@ -15,7 +15,7 @@
   <description>Workflow versioning Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0-rc-2</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
     <testcontainers.version>1.21.4</testcontainers.version>
   </properties>
   <dependencies>

--- a/tutorials/workflow/java/versioning/pom.xml
+++ b/tutorials/workflow/java/versioning/pom.xml
@@ -15,9 +15,21 @@
   <description>Workflow versioning Example</description>
 
   <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
     <testcontainers.version>1.21.4</testcontainers.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -34,12 +46,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tutorials/workflow/java/workflow-management/pom.xml
+++ b/tutorials/workflow/java/workflow-management/pom.xml
@@ -15,7 +15,7 @@
   <description>Workflow Management Example</description>
 
   <properties>
-    <dapr.spring.version>1.17.0</dapr.spring.version>
+    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
   </properties>
   <dependencies>
     <dependency>

--- a/tutorials/workflow/java/workflow-management/pom.xml
+++ b/tutorials/workflow/java/workflow-management/pom.xml
@@ -14,9 +14,18 @@
   <name>workflow-management</name>
   <description>Workflow Management Example</description>
 
-  <properties>
-    <dapr.spring.version>1.18.0-rc-1</dapr.spring.version>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dapr.spring</groupId>
+        <artifactId>dapr-spring-bom</artifactId>
+        <version>1.18.0-rc-1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -33,12 +42,10 @@
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter</artifactId>
-      <version>${dapr.spring.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dapr.spring</groupId>
       <artifactId>dapr-spring-boot-starter-test</artifactId>
-      <version>${dapr.spring.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/workflows/java/sdk/order-processor/pom.xml
+++ b/workflows/java/sdk/order-processor/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk-workflows</artifactId>
-            <version>1.17.0-rc-3</version>
+            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/workflows/java/sdk/order-processor/pom.xml
+++ b/workflows/java/sdk/order-processor/pom.xml
@@ -13,11 +13,23 @@
         <maven.compiler.target>17</maven.compiler.target>
         <slf4jVersion>2.0.13</slf4jVersion>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dapr</groupId>
+                <artifactId>dapr-sdk-bom</artifactId>
+                <version>1.18.0-rc-1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>dapr-sdk-workflows</artifactId>
-            <version>1.18.0-rc-1</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
# Description

Bumps all io.dapr:* Java SDK pins in quickstart samples to 1.18.0-rc-1 (Maven-style tag from dapr/java-sdk)
Covers 5 artifact types: dapr-sdk, dapr-sdk-springboot, dapr-sdk-workflows, dapr-spring-boot-starter, dapr-spring-boot-starter-test
21 pom.xml files updated across bindings, configuration, conversation, jobs, pub_sub, secrets_management, state_management, workflows, and tutorials/workflow samples
Part of Dapr 1.18 release prep (release day May 26, 2026)

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
