### PR TITLE
chore(java): bump Dapr SDK BOM to 1.18.0-rc-2

### DIFF
--- a/bindings/java/sdk/batch/pom.xml
+++ b/bindings/java/sdk/batch/pom.xml
@@ -21,7 +21,7 @@
 			<dependency>
 				<groupId>io.dapr.spring</groupId>
 				<artifactId>dapr-spring-bom</artifactId>
-				<version>1.18.0-rc-1</version>
+				<version>1.18.0-rc-2</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/configuration/java/sdk/order-processor/pom.xml
+++ b/configuration/java/sdk/order-processor/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk-bom</artifactId>
-                <version>1.18.0-rc-1</version>
+                <version>1.18.0-rc-2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/conversation/java/sdk/conversation/pom.xml
+++ b/conversation/java/sdk/conversation/pom.xml
@@ -22,7 +22,7 @@
       <dependency>
         <groupId>io.dapr</groupId>
         <artifactId>dapr-sdk-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/jobs/java/sdk/job-scheduler/pom.xml
+++ b/jobs/java/sdk/job-scheduler/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk-bom</artifactId>
-                <version>1.18.0-rc-1</version>
+                <version>1.18.0-rc-2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/jobs/java/sdk/job-service/pom.xml
+++ b/jobs/java/sdk/job-service/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk-bom</artifactId>
-                <version>1.18.0-rc-1</version>
+                <version>1.18.0-rc-2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pub_sub/java/sdk/checkout/pom.xml
+++ b/pub_sub/java/sdk/checkout/pom.xml
@@ -19,7 +19,7 @@
 			<dependency>
 				<groupId>io.dapr</groupId>
 				<artifactId>dapr-sdk-bom</artifactId>
-				<version>1.18.0-rc-1</version>
+				<version>1.18.0-rc-2</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pub_sub/java/sdk/order-processor/pom.xml
+++ b/pub_sub/java/sdk/order-processor/pom.xml
@@ -22,7 +22,7 @@
 			<dependency>
 				<groupId>io.dapr.spring</groupId>
 				<artifactId>dapr-spring-bom</artifactId>
-				<version>1.18.0-rc-1</version>
+				<version>1.18.0-rc-2</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/secrets_management/java/sdk/order-processor/pom.xml
+++ b/secrets_management/java/sdk/order-processor/pom.xml
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk-bom</artifactId>
-                <version>1.18.0-rc-1</version>
+                <version>1.18.0-rc-2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/state_management/java/sdk/order-processor/pom.xml
+++ b/state_management/java/sdk/order-processor/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk-bom</artifactId>
-                <version>1.18.0-rc-1</version>
+                <version>1.18.0-rc-2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tutorials/workflow/java/child-workflows/pom.xml
+++ b/tutorials/workflow/java/child-workflows/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/combined-patterns/shipping-app/pom.xml
+++ b/tutorials/workflow/java/combined-patterns/shipping-app/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/combined-patterns/workflow-app/pom.xml
+++ b/tutorials/workflow/java/combined-patterns/workflow-app/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/external-system-interactions/pom.xml
+++ b/tutorials/workflow/java/external-system-interactions/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/fan-out-fan-in/pom.xml
+++ b/tutorials/workflow/java/fan-out-fan-in/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/fundamentals/pom.xml
+++ b/tutorials/workflow/java/fundamentals/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/monitor-pattern/pom.xml
+++ b/tutorials/workflow/java/monitor-pattern/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/resiliency-and-compensation/pom.xml
+++ b/tutorials/workflow/java/resiliency-and-compensation/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/task-chaining/pom.xml
+++ b/tutorials/workflow/java/task-chaining/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/versioning/pom.xml
+++ b/tutorials/workflow/java/versioning/pom.xml
@@ -23,7 +23,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/tutorials/workflow/java/workflow-management/pom.xml
+++ b/tutorials/workflow/java/workflow-management/pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>io.dapr.spring</groupId>
         <artifactId>dapr-spring-bom</artifactId>
-        <version>1.18.0-rc-1</version>
+        <version>1.18.0-rc-2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/workflows/java/sdk/order-processor/pom.xml
+++ b/workflows/java/sdk/order-processor/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>io.dapr</groupId>
                 <artifactId>dapr-sdk-bom</artifactId>
-                <version>1.18.0-rc-1</version>
+                <version>1.18.0-rc-2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION

# Description

Bumps io.dapr:dapr-sdk-bom and io.dapr.spring:dapr-spring-bom from 1.18.0-rc-1 to 1.18.0-rc-2 across all 21 Java quickstart samples.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
