### PR TITLE
Make connection failures in service_invocation/csharp/http/checkout visible

### DIFF
--- a/service_invocation/csharp/http/checkout/Program.cs
+++ b/service_invocation/csharp/http/checkout/Program.cs
@@ -14,7 +14,14 @@ for (int i = 1; i <= 20; i++) {
     // Invoking a service
     var response = await client.PostAsJsonAsync("/orders", order, cts.Token);
 
-    Console.WriteLine("Order passed: " + order);
+    if (!response.IsSuccessStatusCode)
+    {
+        Console.WriteLine(response.StatusCode);
+        Console.WriteLine(await response.Content.ReadAsStringAsync());
+    }
+    else {
+        Console.WriteLine("Order passed: " + order);
+    }
 
     await Task.Delay(TimeSpan.FromSeconds(1));
 }


### PR DESCRIPTION
Make connection failures in `service_invocation/csharp/http/checkout` visible.

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1335.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] The quickstart code compiles correctly
* [x] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).