### PR TITLE
docs: fix broken relative links in tutorial READMEs

### DIFF
--- a/tutorials/hello-world/README.md
+++ b/tutorials/hello-world/README.md
@@ -240,7 +240,7 @@ curl -XPOST -d @sample.json -H Content-Type:application/json http://localhost:35
 
 Or, using the Visual Studio Code [Rest Client Plugin](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
 
-[sample.http](sample.http)
+[sample.http](node/sample.http)
 ```http
 POST http://localhost:3500/v1.0/invoke/nodeapp/method/neworder HTTP/1.1
 Content-Type: application/json
@@ -298,7 +298,7 @@ dapr invoke --app-id nodeapp --method order --verb GET
 
 or use the Visual Studio Code [Rest Client Plugin](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
 
-[sample.http](sample.http)
+[sample.http](node/sample.http)
 ```http
 GET http://localhost:3500/v1.0/invoke/nodeapp/method/order
 ```

--- a/tutorials/pub-sub/README.md
+++ b/tutorials/pub-sub/README.md
@@ -746,4 +746,4 @@ Pub-sub allows us to completely decouple the components. Publishers need not be 
 
 ## Next steps:
 
-- Explore additional [quickstarts](../README.md#quickstarts)
+- Explore additional [quickstarts](../../README.md#quickstarts)

--- a/tutorials/workflow/csharp/challenges-tips/README.md
+++ b/tutorials/workflow/csharp/challenges-tips/README.md
@@ -6,5 +6,4 @@ This section provides some tips with code snippets to understand the limitations
 
 - [Deterministic workflows](DeterministicWorkflow.cs)
 - [Idempotent activities](IdempotentActivity.cs)
-- [Versioning workflows](VersioningWorkflow.cs)
 - [Workflow & activity payload size](PayloadSizeWorkflow.cs)

--- a/tutorials/workflow/java/workflow-management/README.md
+++ b/tutorials/workflow/java/workflow-management/README.md
@@ -13,7 +13,7 @@ For more information on workflow management, see the [Dapr docs](https://docs.da
 
 ## Inspect the code
 
-Open the [`WorkflowManagementRestController.java`](src/main/java/io/dapr/springboot/examples/chain/WorkflowManagementRestController.java) file in the `tutorials/workflow/java/workflow-management/` folder. This file contains the endpoint definitions that use the workflow management API. The workflow that is being managed is named `NeverEndingWorkflow` and is a counter that will keep running once it's started.
+Open the [`WorkflowManagementRestController.java`](src/main/java/io/dapr/springboot/examples/WorkflowManagementRestController.java) file in the `tutorials/workflow/java/workflow-management/` folder. This file contains the endpoint definitions that use the workflow management API. The workflow that is being managed is named `NeverEndingWorkflow` and is a counter that will keep running once it's started.
 
 ## Run the tutorial
 


### PR DESCRIPTION
## Description

Four relative Markdown links in the tutorial READMEs point at paths that do not exist in the repository.

| File | Link | Problem |
| --- | --- | --- |
| `tutorials/hello-world/README.md` (x2) | `sample.http` | the file is at `tutorials/hello-world/node/sample.http` |
| `tutorials/pub-sub/README.md` | `../README.md#quickstarts` | resolves to `tutorials/README.md`, which does not exist |
| `tutorials/workflow/java/workflow-management/README.md` | `.../examples/chain/WorkflowManagementRestController.java` | the controller is at `.../examples/WorkflowManagementRestController.java`, there is no `chain/` directory here |
| `tutorials/workflow/csharp/challenges-tips/README.md` | `VersioningWorkflow.cs` | the file does not exist |

For pub-sub, the five sibling tutorials (`bindings`, `distributed-calculator`, `hello-kubernetes`, `observability`, `secretstore`) all use `../../README.md#quickstarts`, so this one is a typo.

For the C# challenges-tips list, the java and python versions of the same README list the same three tips and have no versioning entry either, so this PR drops the dangling bullet to match them rather than inventing a sample. Note there is a separate `tutorials/workflow/{csharp,java,python}/versioning` tutorial. If you would rather point readers at it, linking `../versioning` from all three challenges-tips READMEs would be the consistent way to do it, and I am happy to follow up with that instead.

## Verification

Every relative Markdown link in the repository's 136 READMEs was resolved against the working tree:

```console
before: remaining broken: 4
after:  remaining broken: 0
```

Only Markdown is touched, no sample code changes.
