### PR TITLE
chore: Remove double space in output 

### DIFF
--- a/tutorials/hello-world/README.md
+++ b/tutorials/hello-world/README.md
@@ -444,5 +444,5 @@ For more information on how to configure the files visit [How-To: Debug multiple
 Now that you've gotten Dapr running locally on your machine, consider these next steps:
 - Explore additional quickstarts such as [pub-sub](../pub-sub), [bindings](../bindings) or the [distributed calculator app](../distributed-calculator).
 - Run this hello world application in Kubernetes via the [Hello Kubernetes](../hello-kubernetes) quickstart.
-- Learn more about Dapr in the [Dapr overview](https://docs.dapr.io/concepts/overview/) documentation.
+- Learn more about Dapr in the [Dapr Concepts](https://docs.dapr.io/concepts/) documentation.
 - Explore [Dapr concepts](https://docs.dapr.io/concepts/) such as building blocks and components in the Dapr documentation.

--- a/tutorials/workflow/java/child-workflows/src/main/java/io/dapr/springboot/examples/child/Activity1.java
+++ b/tutorials/workflow/java/child-workflows/src/main/java/io/dapr/springboot/examples/child/Activity1.java
@@ -27,6 +27,6 @@ public class Activity1 implements WorkflowActivity {
     Logger logger = LoggerFactory.getLogger(Activity1.class);
     var input = ctx.getInput(String.class);
     logger.info("{} : Received input: {}.", ctx.getName(), input);
-    return input + "  is processed";
+    return input + " is processed";
   }
 }


### PR DESCRIPTION
# Description

- Remove double space in Child workflow tutorial for Java. 
- Fix outdated Dapr Concepts link

## Issue reference

We strive to have all PRs being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] The quickstart code compiles correctly
* [ ] You've tested new builds of the quickstart if you changed quickstart code
* [ ] You've updated the quickstart's README if necessary
* [ ] If you have changed the steps for a quickstart be sure that you have updated the automated validation accordingly. All of our quickstarts have annotations that allow them to be executed automatically as code. For more information see [mechanical-markdown](https://github.com/dapr/mechanical-markdown#readme). For user guide with examples see [Examples](https://github.com/dapr/mechanical-markdown/tree/main/examples#mechanical-markdown-by-example).
